### PR TITLE
Update Find Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 
 import java.util.function.Predicate;
 
@@ -10,7 +12,6 @@ import seedu.address.model.expense.DateMatchesPredicate;
 import seedu.address.model.expense.Expense;
 import seedu.address.model.expense.NameContainsKeywordsPredicate;
 import seedu.address.model.expense.TagsMatchesPredicate;
-//import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Finds and lists all expenses in address book whose name contains any of the argument keywords.
@@ -20,10 +21,21 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all expenses whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all the expenses with details "
+            + "that match the arguments (keywords, date, tags). "
+            + "Parameters: "
+            + "[" + PREFIX_DESCRIPTION + "KEYWORD] "
+            + "[" + PREFIX_DATE + "DD-MM-YYYY] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + "  "
+            + PREFIX_DATE + "18-02-2020 "
+            + PREFIX_DESCRIPTION + "Lunch at YIH"
+            + PREFIX_TAG + "food";
+
+    /*public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all expenses whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " alice bob charlie";*/
 
     private final NameContainsKeywordsPredicate namePredicate;
     private final DateMatchesPredicate datePredicate;
@@ -51,18 +63,6 @@ public class FindCommand extends Command {
             predicate = predicate.and(tagsPredicate);
         }
         model.updateFilteredExpenseList(predicate);
-        /*
-        requireNonNull(model);
-        if (!namePredicate.isEmpty()) {
-            model.updateFilteredExpenseList(namePredicate);
-        }
-        if (!datePredicate.isEmpty()) {
-            model.updateFilteredExpenseList(datePredicate);
-        }
-        if (!tagsPredicate.isEmpty()) {
-            model.updateFilteredExpenseList(tagsPredicate);
-        }
-         */
         return new CommandResult(
                 String.format(Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW, model.getFilteredExpenseList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -3,10 +3,13 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import seedu.address.logic.parser.FindCommandParser;
 
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.expense.DateMatchesPredicate;
 import seedu.address.model.expense.Expense;
@@ -31,11 +34,6 @@ public class FindCommand extends Command {
             + PREFIX_DATE + "18-02-2020 "
             + PREFIX_DESCRIPTION + "Lunch at YIH"
             + PREFIX_TAG + "food";
-
-    /*public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all expenses whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";*/
 
     private final NameContainsKeywordsPredicate namePredicate;
     private final DateMatchesPredicate datePredicate;

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,15 +1,12 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import seedu.address.logic.parser.FindCommandParser;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Arrays;
 import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.expense.DateMatchesPredicate;
 import seedu.address.model.expense.Expense;
@@ -39,7 +36,14 @@ public class FindCommand extends Command {
     private final DateMatchesPredicate datePredicate;
     private final TagsMatchesPredicate tagsPredicate;
 
-    public FindCommand(NameContainsKeywordsPredicate namePredicate, DateMatchesPredicate datePredicate, TagsMatchesPredicate tagsPredicate) {
+    /**
+     * Constructor that takes in the predicates used to filter through
+     * the expenses list and find matching expenses. It matches based on keywords,
+     * date, and tags.
+     */
+    public FindCommand(NameContainsKeywordsPredicate namePredicate,
+                       DateMatchesPredicate datePredicate,
+                       TagsMatchesPredicate tagsPredicate) {
         this.namePredicate = namePredicate;
         this.datePredicate = datePredicate;
         this.tagsPredicate = tagsPredicate;
@@ -47,7 +51,8 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        if (this.namePredicate.isEmpty() && this.datePredicate.isEmpty() && this.tagsPredicate.isEmpty()) {
+        if (this.namePredicate.isEmpty() && this.datePredicate.isEmpty()
+                && this.tagsPredicate.isEmpty()) {
             model.updateFilteredExpenseList(x -> false);
         }
         Predicate<Expense> predicate = x -> true;
@@ -62,7 +67,8 @@ public class FindCommand extends Command {
         }
         model.updateFilteredExpenseList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW, model.getFilteredExpenseList().size()));
+                String.format(Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW,
+                        model.getFilteredExpenseList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,9 +2,15 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.expense.DateMatchesPredicate;
+import seedu.address.model.expense.Expense;
 import seedu.address.model.expense.NameContainsKeywordsPredicate;
+import seedu.address.model.expense.TagsMatchesPredicate;
+//import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Finds and lists all expenses in address book whose name contains any of the argument keywords.
@@ -19,16 +25,44 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final NameContainsKeywordsPredicate namePredicate;
+    private final DateMatchesPredicate datePredicate;
+    private final TagsMatchesPredicate tagsPredicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    public FindCommand(NameContainsKeywordsPredicate namePredicate, DateMatchesPredicate datePredicate, TagsMatchesPredicate tagsPredicate) {
+        this.namePredicate = namePredicate;
+        this.datePredicate = datePredicate;
+        this.tagsPredicate = tagsPredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
-        requireNonNull(model);
+        if (this.namePredicate.isEmpty() && this.datePredicate.isEmpty() && this.tagsPredicate.isEmpty()) {
+            model.updateFilteredExpenseList(x -> false);
+        }
+        Predicate<Expense> predicate = x -> true;
+        if (!namePredicate.isEmpty()) {
+            predicate = predicate.and(namePredicate);
+        }
+        if (!datePredicate.isEmpty()) {
+            predicate = predicate.and(datePredicate);
+        }
+        if (!tagsPredicate.isEmpty()) {
+            predicate = predicate.and(tagsPredicate);
+        }
         model.updateFilteredExpenseList(predicate);
+        /*
+        requireNonNull(model);
+        if (!namePredicate.isEmpty()) {
+            model.updateFilteredExpenseList(namePredicate);
+        }
+        if (!datePredicate.isEmpty()) {
+            model.updateFilteredExpenseList(datePredicate);
+        }
+        if (!tagsPredicate.isEmpty()) {
+            model.updateFilteredExpenseList(tagsPredicate);
+        }
+         */
         return new CommandResult(
                 String.format(Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW, model.getFilteredExpenseList().size()));
     }
@@ -37,6 +71,8 @@ public class FindCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && namePredicate.equals(((FindCommand) other).namePredicate)
+                && datePredicate.equals(((FindCommand) other).datePredicate)
+                && tagsPredicate.equals(((FindCommand) other).tagsPredicate)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -18,6 +18,7 @@ import seedu.address.model.expense.TagsMatchesPredicate;
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    public static final String MISSING_ARGUMENTS = "You cannot leave arguments empty.";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -40,11 +41,20 @@ public class FindCommandParser implements Parser<FindCommand> {
         List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
             keywords = argMultimap.getValue(PREFIX_DESCRIPTION).get();
+            if (keywords.isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MISSING_ARGUMENTS));
+            }
+        }
+        if (dates.size() == 1 && dates.get(0).isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MISSING_ARGUMENTS));
         }
         for (String date: dates) {
             if (!Date.isValidDate(date)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_CONSTRAINTS));
             }
+        }
+        if (tags.size() == 1 && tags.get(0).isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MISSING_ARGUMENTS));
         }
         if (keywords.isEmpty() && dates.isEmpty() && tags.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -31,30 +31,28 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, //PREFIX_AMOUNT,
                         PREFIX_DATE, PREFIX_TAG);
+
         String keywords = "";
-        String date = "";
+        List<String> dates = argMultimap.getAllValues(PREFIX_DATE);
+        List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
             keywords = argMultimap.getValue(PREFIX_DESCRIPTION).get();
         }
-        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
-            if (!Date.isValidDate(argMultimap.getValue(PREFIX_DATE).get())) {
+        for (String date: dates) {
+            if (!Date.isValidDate(date)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_CONSTRAINTS));
             }
-            date = argMultimap.getValue(PREFIX_DATE).get();
         }
-        List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
-
-        if (keywords.equals("") && date.equals("") && tags.isEmpty()) {
+        if (keywords.isEmpty() && dates.isEmpty() && tags.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         return new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList(keywords.trim().split("\\s+"))),
-                new DateMatchesPredicate(date),
+                new DateMatchesPredicate(dates),
                 new TagsMatchesPredicate(tags)
         );
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -7,14 +7,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Arrays;
 import java.util.List;
 
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.expense.Date;
 import seedu.address.model.expense.DateMatchesPredicate;
 import seedu.address.model.expense.NameContainsKeywordsPredicate;
 import seedu.address.model.expense.TagsMatchesPredicate;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -35,7 +33,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_AMOUNT,
+                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, //PREFIX_AMOUNT,
                         PREFIX_DATE, PREFIX_TAG);
         String keywords = "";
         String date = "";
@@ -43,37 +41,17 @@ public class FindCommandParser implements Parser<FindCommand> {
             keywords = argMultimap.getValue(PREFIX_DESCRIPTION).get();
         }
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            if (!Date.isValidDate(argMultimap.getValue(PREFIX_DATE).get())) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_CONSTRAINTS));
+            }
             date = argMultimap.getValue(PREFIX_DATE).get();
         }
         List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
 
-        // String[] nameKeywords = trimmedArgs.split("\\s+");
+        if (keywords.equals("") && date.equals("") && tags.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
 
-        if (keywords.equals(date) && tags.isEmpty()) {
-            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
-        }
-        /*
-        boolean dateFound = false;
-        Date date;
-        boolean tagsFound = false;
-        Set<Tag> tags = new HashSet<Tag>();
-        for (int i = 0; i < nameKeywords.length; i++) {
-            if (nameKeywords[i].contains("-@") && !dateFound) {
-                if (nameKeywords[i].length() > 2) {
-                    date = new Date(nameKeywords[i].substring(2));
-                } else if (i < nameKeywords.length - 1) {
-                    date = new Date(nameKeywords[i+1]);
-                }
-                dateFound = true;
-            } else if (nameKeywords[i].contains("t/")) {
-                if (nameKeywords[i].length() > 2) {
-                    tags.add(new Tag(nameKeywords[i].substring(2)));
-                } else if (i < nameKeywords.length - 1) {
-                    tags.add(new Tag(nameKeywords[i+1]));
-                }
-            }
-        }
-         */
         return new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList(keywords.trim().split("\\s+"))),
                 new DateMatchesPredicate(date),

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,20 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
+import java.util.List;
 
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.expense.Date;
+import seedu.address.model.expense.DateMatchesPredicate;
 import seedu.address.model.expense.NameContainsKeywordsPredicate;
+import seedu.address.model.expense.TagsMatchesPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -26,9 +34,51 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_AMOUNT,
+                        PREFIX_DATE, PREFIX_TAG);
+        String keywords = "";
+        String date = "";
+        if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
+            keywords = argMultimap.getValue(PREFIX_DESCRIPTION).get();
+        }
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            date = argMultimap.getValue(PREFIX_DATE).get();
+        }
+        List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        // String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        if (keywords.equals(date) && tags.isEmpty()) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+        }
+        /*
+        boolean dateFound = false;
+        Date date;
+        boolean tagsFound = false;
+        Set<Tag> tags = new HashSet<Tag>();
+        for (int i = 0; i < nameKeywords.length; i++) {
+            if (nameKeywords[i].contains("-@") && !dateFound) {
+                if (nameKeywords[i].length() > 2) {
+                    date = new Date(nameKeywords[i].substring(2));
+                } else if (i < nameKeywords.length - 1) {
+                    date = new Date(nameKeywords[i+1]);
+                }
+                dateFound = true;
+            } else if (nameKeywords[i].contains("t/")) {
+                if (nameKeywords[i].length() > 2) {
+                    tags.add(new Tag(nameKeywords[i].substring(2)));
+                } else if (i < nameKeywords.length - 1) {
+                    tags.add(new Tag(nameKeywords[i+1]));
+                }
+            }
+        }
+         */
+        return new FindCommand(
+                new NameContainsKeywordsPredicate(Arrays.asList(keywords.trim().split("\\s+"))),
+                new DateMatchesPredicate(date),
+                new TagsMatchesPredicate(tags)
+        );
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;

--- a/src/main/java/seedu/address/model/expense/Date.java
+++ b/src/main/java/seedu/address/model/expense/Date.java
@@ -14,7 +14,7 @@ import java.time.format.DateTimeParseException;
 public class Date {
     // private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
     public static final String MESSAGE_CONSTRAINTS = "Dates should be of the format dd-MM-yyyy,"
-            + "and it should adhere to the following constraints: "
+            + "and it should adhere to the following constraints:\n"
             + "1. String should not be blank.\n"
             + "2. Date given should be a valid date that exists.\n"
             + "** Note: Date input is optional.";

--- a/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
@@ -12,17 +12,22 @@ public class DateMatchesPredicate implements Predicate<Expense> {
     private final Date date;
 
     public DateMatchesPredicate(String dateString) {
+        this.date = Date.isValidDate(dateString) ? new Date(dateString) : null;
+        /*
         Date temp;
         try {
             temp = new Date(dateString);
         } catch (IllegalArgumentException e) {
             temp = null;
         }
-        this.date = temp;
+        this.date = temp;*/
     }
 
     @Override
     public boolean test(Expense expense) {
+        if (this.date == null) {
+            return false;
+        }
         return this.date.equals(expense.getDate());
     }
     

--- a/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Expense}'s {@code Description} matches any of the keywords given.
  */
@@ -14,28 +12,25 @@ public class DateMatchesPredicate implements Predicate<Expense> {
     private final Set<Date> dates;
 
     public DateMatchesPredicate(List<String> dateStrings) {
-        Set<Date> temp = new HashSet<Date>();
+        Set<Date> temp = new HashSet<>();
         for (String s: dateStrings) {
             if (Date.isValidDate(s)) {
                 temp.add(new Date(s));
             }
-        }
-        if (temp.isEmpty()) {
-            temp = null;
         }
         this.dates = temp;
     }
 
     @Override
     public boolean test(Expense expense) {
-        if (this.dates == null) {
+        if (this.isEmpty()) {
             return false;
         }
         return this.dates.contains(expense.getDate());
     }
     
     public boolean isEmpty() {
-        return this.dates == null;
+        return this.dates.isEmpty();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
@@ -1,0 +1,40 @@
+package seedu.address.model.expense;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Expense}'s {@code Description} matches any of the keywords given.
+ */
+public class DateMatchesPredicate implements Predicate<Expense> {
+    private final Date date;
+
+    public DateMatchesPredicate(String dateString) {
+        Date temp;
+        try {
+            temp = new Date(dateString);
+        } catch (IllegalArgumentException e) {
+            temp = null;
+        }
+        this.date = temp;
+    }
+
+    @Override
+    public boolean test(Expense expense) {
+        return this.date.equals(expense.getDate());
+    }
+    
+    public boolean isEmpty() {
+        return this.date == null;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DateMatchesPredicate // instanceof handles nulls
+                && date.equals(((DateMatchesPredicate) other).date)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
@@ -11,6 +11,10 @@ import java.util.function.Predicate;
 public class DateMatchesPredicate implements Predicate<Expense> {
     private final Set<Date> dates;
 
+    /**
+     * Constructor that takes in a list of strings representing dates.
+     * It stores parsable strings into the dates HashSet.
+     */
     public DateMatchesPredicate(List<String> dateStrings) {
         Set<Date> temp = new HashSet<>();
         for (String s: dateStrings) {
@@ -28,7 +32,10 @@ public class DateMatchesPredicate implements Predicate<Expense> {
         }
         return this.dates.contains(expense.getDate());
     }
-    
+
+    /**
+     * Returns true if there are no dates to match in this predicate. Otherwise, return false.
+     */
     public boolean isEmpty() {
         return this.dates.isEmpty();
     }
@@ -39,5 +46,4 @@ public class DateMatchesPredicate implements Predicate<Expense> {
                 || (other instanceof DateMatchesPredicate // instanceof handles nulls
                 && dates.equals(((DateMatchesPredicate) other).dates)); // state check
     }
-
 }

--- a/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 /**
- * Tests that a {@code Expense}'s {@code Description} matches any of the keywords given.
+ * Tests that any of an {@code Expense}'s {@code Dates} matches any of the keywords given.
  */
 public class DateMatchesPredicate implements Predicate<Expense> {
     private final Set<Date> dates;

--- a/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/DateMatchesPredicate.java
@@ -1,6 +1,8 @@
 package seedu.address.model.expense;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -9,37 +11,38 @@ import seedu.address.commons.util.StringUtil;
  * Tests that a {@code Expense}'s {@code Description} matches any of the keywords given.
  */
 public class DateMatchesPredicate implements Predicate<Expense> {
-    private final Date date;
+    private final Set<Date> dates;
 
-    public DateMatchesPredicate(String dateString) {
-        this.date = Date.isValidDate(dateString) ? new Date(dateString) : null;
-        /*
-        Date temp;
-        try {
-            temp = new Date(dateString);
-        } catch (IllegalArgumentException e) {
+    public DateMatchesPredicate(List<String> dateStrings) {
+        Set<Date> temp = new HashSet<Date>();
+        for (String s: dateStrings) {
+            if (Date.isValidDate(s)) {
+                temp.add(new Date(s));
+            }
+        }
+        if (temp.isEmpty()) {
             temp = null;
         }
-        this.date = temp;*/
+        this.dates = temp;
     }
 
     @Override
     public boolean test(Expense expense) {
-        if (this.date == null) {
+        if (this.dates == null) {
             return false;
         }
-        return this.date.equals(expense.getDate());
+        return this.dates.contains(expense.getDate());
     }
     
     public boolean isEmpty() {
-        return this.date == null;
+        return this.dates == null;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DateMatchesPredicate // instanceof handles nulls
-                && date.equals(((DateMatchesPredicate) other).date)); // state check
+                && dates.equals(((DateMatchesPredicate) other).dates)); // state check
     }
 
 }

--- a/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
@@ -30,7 +30,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Expense> {
     }
 
     public boolean isEmpty() {
-        return this.keywords.isEmpty() || (this.keywords.size() == 1 && this.keywords.get(0).equals(""));
+        return this.keywords.isEmpty() || (this.keywords.size() == 1 && this.keywords.get(0).isEmpty());
     }
 
 }

--- a/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
@@ -31,6 +31,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Expense> {
                 && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
     }
 
+    /**
+     * Returns true if there are no valid keywords in this predicate. Otherwise, return false.
+     */
     public boolean isEmpty() {
         return this.keywords.isEmpty() || (this.keywords.size() == 1 && this.keywords.contains(""));
     }

--- a/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
@@ -29,4 +29,8 @@ public class NameContainsKeywordsPredicate implements Predicate<Expense> {
                 && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
     }
 
+    public boolean isEmpty() {
+        return this.keywords.isEmpty() || (this.keywords.size() == 1 && this.keywords.get(0).equals(""));
+    }
+
 }

--- a/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/expense/NameContainsKeywordsPredicate.java
@@ -1,6 +1,8 @@
 package seedu.address.model.expense;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -9,10 +11,10 @@ import seedu.address.commons.util.StringUtil;
  * Tests that a {@code Expense}'s {@code Description} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Expense> {
-    private final List<String> keywords;
+    private final Set<String> keywords;
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+        this.keywords = new HashSet<>(keywords);
     }
 
     @Override
@@ -30,7 +32,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Expense> {
     }
 
     public boolean isEmpty() {
-        return this.keywords.isEmpty() || (this.keywords.size() == 1 && this.keywords.get(0).isEmpty());
+        return this.keywords.isEmpty() || (this.keywords.size() == 1 && this.keywords.contains(""));
     }
 
 }

--- a/src/main/java/seedu/address/model/expense/TagsMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/TagsMatchesPredicate.java
@@ -7,7 +7,7 @@ import java.util.function.Predicate;
 import seedu.address.model.tag.Tag;
 
 /**
- * Tests that a {@code Expense}'s {@code Description} matches any of the keywords given.
+ * Tests that any of an {@code Expense}'s {@code Tags} matches any of the tags given.
  */
 public class TagsMatchesPredicate implements Predicate<Expense> {
     private final HashSet<Tag> tags;

--- a/src/main/java/seedu/address/model/expense/TagsMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/TagsMatchesPredicate.java
@@ -12,6 +12,9 @@ import seedu.address.model.tag.Tag;
 public class TagsMatchesPredicate implements Predicate<Expense> {
     private final HashSet<Tag> tags;
 
+    /**
+     * Constructor that takes in a list of strings to match.
+     */
     public TagsMatchesPredicate(List<String> tagStrings) {
         this.tags = new HashSet<>();
         for (String i: tagStrings) {
@@ -29,6 +32,9 @@ public class TagsMatchesPredicate implements Predicate<Expense> {
         return false;
     }
 
+    /**
+     * Returns true if there are no tags to match in this predicate. Otherwise, return false.
+     */
     public boolean isEmpty() {
         return tags.isEmpty();
     }

--- a/src/main/java/seedu/address/model/expense/TagsMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/expense/TagsMatchesPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.expense;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code Expense}'s {@code Description} matches any of the keywords given.
+ */
+public class TagsMatchesPredicate implements Predicate<Expense> {
+    private final HashSet<Tag> tags;
+
+    public TagsMatchesPredicate(List<String> tagStrings) {
+        this.tags = new HashSet<>();
+        for (String i: tagStrings) {
+            this.tags.add(new Tag(i));
+        }
+    }
+
+    @Override
+    public boolean test(Expense expense) {
+        for (Tag t: this.tags) {
+            if (expense.getTags().contains(t)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isEmpty() {
+        return tags.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagsMatchesPredicate // instanceof handles nulls
+                && tags.equals(((TagsMatchesPredicate) other).tags)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -36,9 +36,9 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
         DateMatchesPredicate firstDatePredicate =
-                new DateMatchesPredicate("09-08-2020");
+                new DateMatchesPredicate(Arrays.asList("09-08-2020"));
         DateMatchesPredicate secondDatePredicate =
-                new DateMatchesPredicate("09-08-2020");
+                new DateMatchesPredicate(Arrays.asList("09-08-2020"));
         TagsMatchesPredicate firstTagsPredicate =
                 new TagsMatchesPredicate(Arrays.asList("tagOne", "tagThree", "tagFour"));
         TagsMatchesPredicate secondTagsPredicate =
@@ -70,7 +70,7 @@ public class FindCommandTest {
     public void execute_zeroKeywords_noExpenseFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        DateMatchesPredicate datePredicate = new DateMatchesPredicate("");
+        DateMatchesPredicate datePredicate = new DateMatchesPredicate(Arrays.asList(""));
         TagsMatchesPredicate tagsPredicate = new TagsMatchesPredicate(null);
         FindCommand command = new FindCommand(predicate, datePredicate, tagsPredicate);
         expectedModel.updateFilteredExpenseList(predicate);
@@ -82,7 +82,7 @@ public class FindCommandTest {
     public void execute_multipleKeywords_multipleExpensesFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 3);
         DateMatchesPredicate datePredicate =
-                new DateMatchesPredicate("09-08-2020");
+                new DateMatchesPredicate(Arrays.asList("09-08-2020"));
         TagsMatchesPredicate tagsPredicate =
                 new TagsMatchesPredicate(Arrays.asList("tagTwo", "bye"));
         NameContainsKeywordsPredicate namePredicate = preparePredicate("Kurz Elle Kunz");

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.testutil.TypicalExpenses.CARL;
 import static seedu.address.testutil.TypicalExpenses.ELLE;
 import static seedu.address.testutil.TypicalExpenses.FIONA;
 import static seedu.address.testutil.TypicalExpenses.getTypicalAddressBook;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -67,13 +70,15 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noExpenseFound() {
+    public void execute_noMatchingKeywords_noExpenseFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        DateMatchesPredicate datePredicate = new DateMatchesPredicate(Arrays.asList(""));
-        TagsMatchesPredicate tagsPredicate = new TagsMatchesPredicate(null);
-        FindCommand command = new FindCommand(predicate, datePredicate, tagsPredicate);
-        expectedModel.updateFilteredExpenseList(predicate);
+        DateMatchesPredicate datePredicate =
+                new DateMatchesPredicate(Collections.emptyList());
+        TagsMatchesPredicate tagsPredicate =
+                new TagsMatchesPredicate(Collections.emptyList());
+        NameContainsKeywordsPredicate namePredicate = preparePredicate("CannotBeNotFound");
+        FindCommand command = new FindCommand(namePredicate, datePredicate, tagsPredicate);
+        expectedModel.updateFilteredExpenseList(namePredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredExpenseList());
     }
@@ -82,9 +87,9 @@ public class FindCommandTest {
     public void execute_multipleKeywords_multipleExpensesFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 3);
         DateMatchesPredicate datePredicate =
-                new DateMatchesPredicate(Arrays.asList("09-08-2020"));
+                new DateMatchesPredicate(Collections.emptyList());
         TagsMatchesPredicate tagsPredicate =
-                new TagsMatchesPredicate(Arrays.asList("tagTwo", "bye"));
+                new TagsMatchesPredicate(Collections.emptyList());
         NameContainsKeywordsPredicate namePredicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(namePredicate, datePredicate, tagsPredicate);
         expectedModel.updateFilteredExpenseList(namePredicate);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -4,15 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.testutil.TypicalExpenses.CARL;
 import static seedu.address.testutil.TypicalExpenses.ELLE;
 import static seedu.address.testutil.TypicalExpenses.FIONA;
 import static seedu.address.testutil.TypicalExpenses.getTypicalAddressBook;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,7 +18,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.expense.DateMatchesPredicate;
 import seedu.address.model.expense.NameContainsKeywordsPredicate;
+import seedu.address.model.expense.TagsMatchesPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -33,15 +35,25 @@ public class FindCommandTest {
                 new NameContainsKeywordsPredicate(Collections.singletonList("first"));
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
-
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        DateMatchesPredicate firstDatePredicate =
+                new DateMatchesPredicate("09-08-2020");
+        DateMatchesPredicate secondDatePredicate =
+                new DateMatchesPredicate("09-08-2020");
+        TagsMatchesPredicate firstTagsPredicate =
+                new TagsMatchesPredicate(Arrays.asList("tagOne", "tagThree", "tagFour"));
+        TagsMatchesPredicate secondTagsPredicate =
+                new TagsMatchesPredicate(Arrays.asList("tagTwo", "bye"));
+        FindCommand findFirstCommand = new FindCommand(
+                firstPredicate, firstDatePredicate, firstTagsPredicate);
+        FindCommand findSecondCommand = new FindCommand(
+                secondPredicate, secondDatePredicate, secondTagsPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(
+                firstPredicate, firstDatePredicate, firstTagsPredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -58,7 +70,9 @@ public class FindCommandTest {
     public void execute_zeroKeywords_noExpenseFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+        DateMatchesPredicate datePredicate = new DateMatchesPredicate("");
+        TagsMatchesPredicate tagsPredicate = new TagsMatchesPredicate(null);
+        FindCommand command = new FindCommand(predicate, datePredicate, tagsPredicate);
         expectedModel.updateFilteredExpenseList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredExpenseList());
@@ -67,9 +81,13 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multipleExpensesFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredExpenseList(predicate);
+        DateMatchesPredicate datePredicate =
+                new DateMatchesPredicate("09-08-2020");
+        TagsMatchesPredicate tagsPredicate =
+                new TagsMatchesPredicate(Arrays.asList("tagTwo", "bye"));
+        NameContainsKeywordsPredicate namePredicate = preparePredicate("Kurz Elle Kunz");
+        FindCommand command = new FindCommand(namePredicate, datePredicate, tagsPredicate);
+        expectedModel.updateFilteredExpenseList(namePredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredExpenseList());
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -11,7 +11,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -27,8 +29,11 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.expense.*;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.expense.DateMatchesPredicate;
+import seedu.address.model.expense.Expense;
+import seedu.address.model.expense.NameContainsKeywordsPredicate;
+import seedu.address.model.expense.Remark;
+import seedu.address.model.expense.TagsMatchesPredicate;
 import seedu.address.testutil.EditExpenseDescriptorBuilder;
 import seedu.address.testutil.ExpenseBuilder;
 import seedu.address.testutil.ExpenseUtil;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -75,7 +75,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        List<String> dateString = Arrays.asList("09-10-2020");
+        String dateString = "09-10-2020";
+        List<String> dateStrings = Arrays.asList(dateString);
         List<String> hs = new ArrayList<>();
         hs.add("CS");
         hs.add("bee");
@@ -87,7 +88,7 @@ public class AddressBookParserTest {
         );
         FindCommand findCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(keywords),
-                new DateMatchesPredicate(dateString),
+                new DateMatchesPredicate(dateStrings),
                 new TagsMatchesPredicate(hs)
         );
         assertEquals(findCommand, command);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -75,7 +75,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        String dateString = "09-10-2020";
+        List<String> dateString = Arrays.asList("09-10-2020");
         List<String> hs = new ArrayList<>();
         hs.add("CS");
         hs.add("bee");

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,12 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -25,9 +27,8 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.expense.Expense;
-import seedu.address.model.expense.NameContainsKeywordsPredicate;
-import seedu.address.model.expense.Remark;
+import seedu.address.model.expense.*;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditExpenseDescriptorBuilder;
 import seedu.address.testutil.ExpenseBuilder;
 import seedu.address.testutil.ExpenseUtil;
@@ -74,9 +75,22 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        String dateString = "09-10-2020";
+        List<String> hs = new ArrayList<>();
+        hs.add("CS");
+        hs.add("bee");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " " + PREFIX_DESCRIPTION + " "
+                        + keywords.stream().collect(Collectors.joining(" "))
+                        + " " + PREFIX_DATE + dateString + " " + PREFIX_TAG
+                        + "CS " + PREFIX_TAG + "bee"
+        );
+        FindCommand findCommand = new FindCommand(
+                new NameContainsKeywordsPredicate(keywords),
+                new DateMatchesPredicate(dateString),
+                new TagsMatchesPredicate(hs)
+        );
+        assertEquals(findCommand, command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -121,7 +121,6 @@ public class EditCommandParserTest {
         EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder().withAmount(VALID_AMOUNT_BOB)
                 .withDate(VALID_DATE_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -22,7 +22,26 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyKeyword_throwsParseException() {
+        assertParseFailure(parser, " " + PREFIX_DESCRIPTION,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommandParser.MISSING_ARGUMENTS));
+    }
+
+    @Test
+    public void parse_emptyDate_throwsParseException() {
+        assertParseFailure(parser, " " + PREFIX_DATE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommandParser.MISSING_ARGUMENTS));
+    }
+
+    @Test
+    public void parse_emptyTag_throwsParseException() {
+        assertParseFailure(parser, " " + PREFIX_TAG,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommandParser.MISSING_ARGUMENTS));
     }
 
     @Test
@@ -33,12 +52,9 @@ public class FindCommandParserTest {
                 new DateMatchesPredicate(Arrays.asList("07-09-2020")),
                 new TagsMatchesPredicate(Arrays.asList("crypto", "cs"))
         );
-        String x = "-d Alice Bob -@ 07-09-2020 t/ crypto t/ cs";
+        String x = " " + PREFIX_DESCRIPTION + "Alice Bob " + PREFIX_DATE + " 07-09-2020 " + PREFIX_TAG +
+                " crypto "+ PREFIX_TAG + " cs";
         assertParseSuccess(parser, x, expectedFindCommand);
-
-        // multiple whitespaces between keywords
-        String y = "\n-d Alice \n \t Bob \n \t -@07-09-2020 t/ crypto t/ cs";
-        assertParseSuccess(parser, y, expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,7 +12,9 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.expense.DateMatchesPredicate;
 import seedu.address.model.expense.NameContainsKeywordsPredicate;
+import seedu.address.model.expense.TagsMatchesPredicate;
 
 public class FindCommandParserTest {
 
@@ -23,12 +28,17 @@ public class FindCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        FindCommand expectedFindCommand = new FindCommand(
+                new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
+                new DateMatchesPredicate("07-09-2020"),
+                new TagsMatchesPredicate(Arrays.asList("crypto", "cs"))
+        );
+        String x = "-d Alice Bob -@ 07-09-2020 t/ crypto t/ cs";
+        assertParseSuccess(parser, x, expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        String y = "\n-d Alice \n \t Bob \n \t -@07-09-2020 t/ crypto t/ cs";
+        assertParseSuccess(parser, y, expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -30,7 +30,7 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
-                new DateMatchesPredicate("07-09-2020"),
+                new DateMatchesPredicate(Arrays.asList("07-09-2020")),
                 new TagsMatchesPredicate(Arrays.asList("crypto", "cs"))
         );
         String x = "-d Alice Bob -@ 07-09-2020 t/ crypto t/ cs";

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -46,15 +46,13 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
         FindCommand expectedFindCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
                 new DateMatchesPredicate(Arrays.asList("07-09-2020")),
                 new TagsMatchesPredicate(Arrays.asList("crypto", "cs"))
         );
-        String x = " " + PREFIX_DESCRIPTION + "Alice Bob " + PREFIX_DATE + " 07-09-2020 " + PREFIX_TAG +
-                " crypto "+ PREFIX_TAG + " cs";
+        String x = " " + PREFIX_DESCRIPTION + "Alice Bob " + PREFIX_DATE + " 07-09-2020 " + PREFIX_TAG
+                 + " crypto " + PREFIX_TAG + " cs";
         assertParseSuccess(parser, x, expectedFindCommand);
     }
-
 }


### PR DESCRIPTION
Fixes #41  

Current functionality of find feature allows user to:
- Obtain a filtered view of expense list containing specific keywords and/or dates and/or tags.
- At least one of the three input argument types (keyword, dates, tags) must be present.
- An expense will be displayed as long as it matches one of the keywords, one of the dates, and one of the tags in the argument, unless any of these arguments are not added to the filter.

Sample usage:
`find -d books mala -@07-08-2020 -@09-10-2020 t/school t/lunch t/food`