### PR TITLE
Add Alias Feature (Command Shortcuts)

### DIFF
--- a/src/main/java/seedu/expense/MainApp.java
+++ b/src/main/java/seedu/expense/MainApp.java
@@ -1,10 +1,5 @@
 package seedu.expense;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.logging.Logger;
-
 import javafx.application.Application;
 import javafx.stage.Stage;
 import seedu.expense.commons.core.Config;
@@ -15,21 +10,16 @@ import seedu.expense.commons.util.ConfigUtil;
 import seedu.expense.commons.util.StringUtil;
 import seedu.expense.logic.Logic;
 import seedu.expense.logic.LogicManager;
-import seedu.expense.model.ExpenseBook;
-import seedu.expense.model.Model;
-import seedu.expense.model.ModelManager;
-import seedu.expense.model.ReadOnlyExpenseBook;
-import seedu.expense.model.ReadOnlyUserPrefs;
-import seedu.expense.model.UserPrefs;
+import seedu.expense.model.*;
 import seedu.expense.model.util.SampleDataUtil;
-import seedu.expense.storage.ExpenseBookStorage;
-import seedu.expense.storage.JsonExpenseBookStorage;
-import seedu.expense.storage.JsonUserPrefsStorage;
-import seedu.expense.storage.Storage;
-import seedu.expense.storage.StorageManager;
-import seedu.expense.storage.UserPrefsStorage;
+import seedu.expense.storage.*;
 import seedu.expense.ui.Ui;
 import seedu.expense.ui.UiManager;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
 
 /**
  * Runs the application.
@@ -57,7 +47,8 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
         ExpenseBookStorage expenseBookStorage = new JsonExpenseBookStorage(userPrefs.getExpenseBookFilePath());
-        storage = new StorageManager(expenseBookStorage, userPrefsStorage);
+        JsonAliasMapStorage aliasMapStorage = new JsonAliasMapStorage(userPrefs.getAliasMapFilePath());
+        storage = new StorageManager(expenseBookStorage, userPrefsStorage, aliasMapStorage);
 
         initLogging(config);
 

--- a/src/main/java/seedu/expense/MainApp.java
+++ b/src/main/java/seedu/expense/MainApp.java
@@ -1,5 +1,10 @@
 package seedu.expense;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
 import javafx.application.Application;
 import javafx.stage.Stage;
 import seedu.expense.commons.core.Config;
@@ -10,17 +15,23 @@ import seedu.expense.commons.util.ConfigUtil;
 import seedu.expense.commons.util.StringUtil;
 import seedu.expense.logic.Logic;
 import seedu.expense.logic.LogicManager;
-import seedu.expense.model.*;
+import seedu.expense.model.ExpenseBook;
+import seedu.expense.model.Model;
+import seedu.expense.model.ModelManager;
+import seedu.expense.model.ReadOnlyExpenseBook;
+import seedu.expense.model.ReadOnlyUserPrefs;
+import seedu.expense.model.UserPrefs;
 import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.util.SampleDataUtil;
-import seedu.expense.storage.*;
+import seedu.expense.storage.ExpenseBookStorage;
+import seedu.expense.storage.JsonAliasMapStorage;
+import seedu.expense.storage.JsonExpenseBookStorage;
+import seedu.expense.storage.JsonUserPrefsStorage;
+import seedu.expense.storage.Storage;
+import seedu.expense.storage.StorageManager;
+import seedu.expense.storage.UserPrefsStorage;
 import seedu.expense.ui.Ui;
 import seedu.expense.ui.UiManager;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.logging.Logger;
 
 /**
  * Runs the application.

--- a/src/main/java/seedu/expense/MainApp.java
+++ b/src/main/java/seedu/expense/MainApp.java
@@ -11,6 +11,7 @@ import seedu.expense.commons.util.StringUtil;
 import seedu.expense.logic.Logic;
 import seedu.expense.logic.LogicManager;
 import seedu.expense.model.*;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.util.SampleDataUtil;
 import seedu.expense.storage.*;
 import seedu.expense.ui.Ui;
@@ -66,7 +67,9 @@ public class MainApp extends Application {
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
         Optional<ReadOnlyExpenseBook> expenseBookOptional;
+        Optional<AliasMap> aliasMapOptional;
         ReadOnlyExpenseBook initialData;
+        AliasMap aliasMap;
         try {
             expenseBookOptional = storage.readExpenseBook();
             if (!expenseBookOptional.isPresent()) {
@@ -80,8 +83,21 @@ public class MainApp extends Application {
             logger.warning("Problem while reading from the file. Will be starting with an empty ExpenseBook");
             initialData = new ExpenseBook();
         }
+        try {
+            aliasMapOptional = storage.readAliasMap();
+            if (!aliasMapOptional.isPresent()) {
+                logger.info("Alias file not found. Will be starting with default settings");
+            }
+            aliasMap = aliasMapOptional.orElseGet(SampleDataUtil::getSampleAliasMap);
+        } catch (DataConversionException e) {
+            logger.warning("Data file not in the correct format. Will be starting with default commands");
+            aliasMap = new AliasMap();
+        } catch (IOException e) {
+            logger.warning("Problem while reading from the file. Will be starting with default commands");
+            aliasMap = new AliasMap();
+        }
 
-        return new ModelManager(initialData, userPrefs);
+        return new ModelManager(initialData, userPrefs, aliasMap);
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/expense/logic/LogicManager.java
+++ b/src/main/java/seedu/expense/logic/LogicManager.java
@@ -1,5 +1,9 @@
 package seedu.expense.logic;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
 import javafx.collections.ObservableList;
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.commons.core.LogsCenter;
@@ -12,10 +16,6 @@ import seedu.expense.model.Model;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.storage.Storage;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.logging.Logger;
 
 /**
  * The main LogicManager of the app.

--- a/src/main/java/seedu/expense/logic/LogicManager.java
+++ b/src/main/java/seedu/expense/logic/LogicManager.java
@@ -27,6 +27,7 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final ExpenseBookParser expenseBookParser;
+
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
      */

--- a/src/main/java/seedu/expense/logic/LogicManager.java
+++ b/src/main/java/seedu/expense/logic/LogicManager.java
@@ -1,9 +1,5 @@
 package seedu.expense.logic;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.logging.Logger;
-
 import javafx.collections.ObservableList;
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.commons.core.LogsCenter;
@@ -16,6 +12,10 @@ import seedu.expense.model.Model;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.storage.Storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.logging.Logger;
 
 /**
  * The main LogicManager of the app.
@@ -42,11 +42,12 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = expenseBookParser.parseCommand(commandText);
+        Command command = expenseBookParser.parseCommand(commandText, model.getAliasMap());
         commandResult = command.execute(model);
 
         try {
             storage.saveExpenseBook(model.getExpenseBook());
+            storage.saveAliasMap(model.getAliasMap());
         } catch (IOException ioe) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }

--- a/src/main/java/seedu/expense/logic/LogicManager.java
+++ b/src/main/java/seedu/expense/logic/LogicManager.java
@@ -27,7 +27,6 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final ExpenseBookParser expenseBookParser;
-
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
      */

--- a/src/main/java/seedu/expense/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AliasCommand.java
@@ -20,7 +20,7 @@ public class AliasCommand extends Command {
             + "[Command's current custom alias or if command has none, default command word]\n"
             + "Example: " + COMMAND_WORD + " find " + "get ";
 
-    public static final String MESSAGE_EDIT_ALIAS_SUCCESS = "Edited alias: %s becomes %s";
+    public static final String MESSAGE_EDIT_ALIAS_SUCCESS = "Edited alias: [%s] becomes [%s]";
 
     private final String previousAlias;
     private final String newAlias;
@@ -40,8 +40,8 @@ public class AliasCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        String actualCommand = model.getAliasMap().getValue(previousAlias);
         try {
+            String actualCommand = model.getAliasMap().getValue(previousAlias);
             model.setAlias(new AliasEntry(previousAlias, actualCommand),
                     new AliasEntry(newAlias, actualCommand));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/seedu/expense/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AliasCommand.java
@@ -1,0 +1,71 @@
+package seedu.expense.logic.commands;
+
+import seedu.expense.logic.commands.exceptions.CommandException;
+import seedu.expense.model.Model;
+import seedu.expense.model.alias.AliasEntry;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Edits the details of an existing expense in the expense book.
+ */
+public class AliasCommand extends Command {
+
+    public static final String COMMAND_WORD = "alias";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Gives a command a customised alias. "
+            + "Alias must not be the same as the default command words and the 'alias' command cannot have an alias. "
+            + "Parameters: "
+            + "[Alias you want to set for a specific command] "
+            + "[Command's current alias or if none, default command word]"
+            + "Example: " + COMMAND_WORD + " find " + "get ";
+
+    public static final String MESSAGE_EDIT_ALIAS_SUCCESS = "Edited alias: %s becomes %s";
+
+    private final String previousAlias;
+    private final String newAlias;
+
+    /**
+     * @param previousAlias   of a command, or default keyword
+     * @param newAlias      to set to a command
+     */
+    public AliasCommand(String previousAlias, String newAlias) {
+        requireNonNull(previousAlias);
+        requireNonNull(newAlias);
+
+        this.previousAlias = previousAlias;
+        this.newAlias = newAlias;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        String actualCommand = model.getAliasMap().getValue(previousAlias);
+        try {
+            model.setAlias(new AliasEntry(previousAlias, actualCommand),
+                    new AliasEntry(newAlias, actualCommand));
+        } catch (IllegalArgumentException e) {
+            throw new CommandException(e.getMessage());
+        }
+        return new CommandResult(String.format(MESSAGE_EDIT_ALIAS_SUCCESS, previousAlias, newAlias));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditCommand)) {
+            return false;
+        }
+
+        // state check
+        AliasCommand e = (AliasCommand) other;
+        return previousAlias.equals(e.previousAlias)
+                && newAlias.equals(e.newAlias);
+    }
+
+}

--- a/src/main/java/seedu/expense/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AliasCommand.java
@@ -1,10 +1,10 @@
 package seedu.expense.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.expense.logic.commands.exceptions.CommandException;
 import seedu.expense.model.Model;
 import seedu.expense.model.alias.AliasEntry;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Edits the alias of an existing commands in the alias map.

--- a/src/main/java/seedu/expense/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AliasCommand.java
@@ -7,17 +7,17 @@ import seedu.expense.model.alias.AliasEntry;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Edits the details of an existing expense in the expense book.
+ * Edits the alias of an existing commands in the alias map.
  */
 public class AliasCommand extends Command {
 
     public static final String COMMAND_WORD = "alias";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Gives a command a customised alias. "
-            + "Alias must not be the same as the default command words and the 'alias' command cannot have an alias. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Gives a command a customised alias.\n"
+            + "Alias must not be the same as the default command words and the 'alias' command cannot have an alias.\n"
             + "Parameters: "
             + "[Alias you want to set for a specific command] "
-            + "[Command's current alias or if none, default command word]"
+            + "[Command's current custom alias or if command has none, default command word]\n"
             + "Example: " + COMMAND_WORD + " find " + "get ";
 
     public static final String MESSAGE_EDIT_ALIAS_SUCCESS = "Edited alias: %s becomes %s";

--- a/src/main/java/seedu/expense/logic/parser/AliasCommandParser.java
+++ b/src/main/java/seedu/expense/logic/parser/AliasCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.expense.logic.parser;
+
+import seedu.expense.logic.commands.AliasCommand;
+import seedu.expense.logic.parser.exceptions.ParseException;
+
+import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new AliasCommand object
+ */
+public class AliasCommandParser implements Parser<AliasCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AliasCommand
+     * and returns an AliasCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AliasCommand parse(String args) throws ParseException {
+        // argMultimap stores mapping of prefixes to respective arguments
+        String[] argsArr = args.trim().split("\\s+");
+
+        if (argsArr.length != 2) {
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, AliasCommand.MESSAGE_USAGE));
+        }
+
+        return new AliasCommand(argsArr[0], argsArr[1]);
+    }
+
+}

--- a/src/main/java/seedu/expense/logic/parser/AliasCommandParser.java
+++ b/src/main/java/seedu/expense/logic/parser/AliasCommandParser.java
@@ -1,9 +1,9 @@
 package seedu.expense.logic.parser;
 
+import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.expense.logic.commands.AliasCommand;
 import seedu.expense.logic.parser.exceptions.ParseException;
-
-import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new AliasCommand object

--- a/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
+++ b/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
@@ -1,23 +1,15 @@
 package seedu.expense.logic.parser;
 
-import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import seedu.expense.logic.commands.*;
+import seedu.expense.logic.parser.exceptions.ParseException;
+import seedu.expense.model.alias.AliasMap;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.expense.logic.commands.AddCommand;
-import seedu.expense.logic.commands.ClearCommand;
-import seedu.expense.logic.commands.Command;
-import seedu.expense.logic.commands.DeleteCommand;
-import seedu.expense.logic.commands.EditCommand;
-import seedu.expense.logic.commands.ExitCommand;
-import seedu.expense.logic.commands.FindCommand;
-import seedu.expense.logic.commands.HelpCommand;
-import seedu.expense.logic.commands.ListCommand;
-import seedu.expense.logic.commands.RemarkCommand;
-import seedu.expense.logic.commands.TopupCommand;
-import seedu.expense.logic.parser.exceptions.ParseException;
+import static java.util.Objects.requireNonNull;
+import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 /**
  * Parses user input.
@@ -81,4 +73,53 @@ public class ExpenseBookParser {
         }
     }
 
+    public Command parseCommand(String userInput, AliasMap aliasMap) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        String commandWord = matcher.group("commandWord");
+
+        requireNonNull(aliasMap);
+        if (aliasMap.hasAlias(commandWord)) {
+            commandWord = aliasMap.getValue(commandWord);
+        }
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+
+        case AddCommand.COMMAND_WORD:
+            return new AddCommandParser().parse(arguments);
+
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
+
+        case DeleteCommand.COMMAND_WORD:
+            return new DeleteCommandParser().parse(arguments);
+
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
+
+        case FindCommand.COMMAND_WORD:
+            return new FindCommandParser().parse(arguments);
+
+        case ListCommand.COMMAND_WORD:
+            return new ListCommand();
+
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
+
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
+
+        case RemarkCommand.COMMAND_WORD:
+            return new RemarkCommandParser().parse(arguments);
+
+        case TopupCommand.COMMAND_WORD:
+            return new TopupCommandParser().parse(arguments);
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
 }

--- a/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
+++ b/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
@@ -9,7 +9,6 @@ import seedu.expense.model.alias.AliasMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -31,51 +30,7 @@ public class ExpenseBookParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
-        }
-
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
-        switch (commandWord) {
-
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
-
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
-
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
-
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
-
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
-
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
-
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
-
-        case RemarkCommand.COMMAND_WORD:
-            return new RemarkCommandParser().parse(arguments);
-
-        case TopupCommand.COMMAND_WORD:
-            return new TopupCommandParser().parse(arguments);
-
-        case AliasCommand.COMMAND_WORD:
-            return new AliasCommandParser().parse(arguments);
-
-        default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
-        }
+        return parseCommand(userInput, null);
     }
 
     public Command parseCommand(String userInput, AliasMap aliasMap) throws ParseException {
@@ -85,8 +40,7 @@ public class ExpenseBookParser {
         }
 
         String commandWord = matcher.group("commandWord");
-        requireNonNull(aliasMap);
-        if (aliasMap.hasAlias(commandWord)) {
+        if (aliasMap != null && aliasMap.hasAlias(commandWord)) {
             commandWord = aliasMap.getValue(commandWord);
         }
         final String arguments = matcher.group("arguments");

--- a/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
+++ b/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
@@ -1,16 +1,27 @@
 package seedu.expense.logic.parser;
 
-import seedu.expense.commons.core.LogsCenter;
-import seedu.expense.logic.LogicManager;
-import seedu.expense.logic.commands.*;
-import seedu.expense.logic.parser.exceptions.ParseException;
-import seedu.expense.model.alias.AliasMap;
+import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import seedu.expense.commons.core.LogsCenter;
+import seedu.expense.logic.LogicManager;
+import seedu.expense.logic.commands.AddCommand;
+import seedu.expense.logic.commands.AliasCommand;
+import seedu.expense.logic.commands.ClearCommand;
+import seedu.expense.logic.commands.Command;
+import seedu.expense.logic.commands.DeleteCommand;
+import seedu.expense.logic.commands.EditCommand;
+import seedu.expense.logic.commands.ExitCommand;
+import seedu.expense.logic.commands.FindCommand;
+import seedu.expense.logic.commands.HelpCommand;
+import seedu.expense.logic.commands.ListCommand;
+import seedu.expense.logic.commands.RemarkCommand;
+import seedu.expense.logic.commands.TopupCommand;
+import seedu.expense.logic.parser.exceptions.ParseException;
+import seedu.expense.model.alias.AliasMap;
 
 /**
  * Parses user input.
@@ -33,6 +44,15 @@ public class ExpenseBookParser {
         return parseCommand(userInput, null);
     }
 
+    /**
+     * Parses user input into command for execution.
+     * Accepts an aliasMap as a dictionary to translate aliases into COMMAND_WORD.
+     *
+     * @param userInput full user input string
+     * @param aliasMap alias dictionary
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public Command parseCommand(String userInput, AliasMap aliasMap) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {

--- a/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
+++ b/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
@@ -1,5 +1,7 @@
 package seedu.expense.logic.parser;
 
+import seedu.expense.commons.core.LogsCenter;
+import seedu.expense.logic.LogicManager;
 import seedu.expense.logic.commands.*;
 import seedu.expense.logic.parser.exceptions.ParseException;
 import seedu.expense.model.alias.AliasMap;
@@ -68,6 +70,9 @@ public class ExpenseBookParser {
         case TopupCommand.COMMAND_WORD:
             return new TopupCommandParser().parse(arguments);
 
+        case AliasCommand.COMMAND_WORD:
+            return new AliasCommandParser().parse(arguments);
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
@@ -80,12 +85,13 @@ public class ExpenseBookParser {
         }
 
         String commandWord = matcher.group("commandWord");
-
         requireNonNull(aliasMap);
         if (aliasMap.hasAlias(commandWord)) {
             commandWord = aliasMap.getValue(commandWord);
         }
         final String arguments = matcher.group("arguments");
+        LogsCenter.getLogger(LogicManager.class).info(
+                "----------------[USER COMMAND][" + commandWord + " " + arguments + "]");
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
@@ -117,6 +123,9 @@ public class ExpenseBookParser {
 
         case TopupCommand.COMMAND_WORD:
             return new TopupCommandParser().parse(arguments);
+
+        case AliasCommand.COMMAND_WORD:
+            return new AliasCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/expense/model/Model.java
+++ b/src/main/java/seedu/expense/model/Model.java
@@ -5,6 +5,8 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.expense.commons.core.GuiSettings;
+import seedu.expense.model.alias.AliasEntry;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.budget.Budget;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
@@ -82,6 +84,18 @@ public interface Model {
      * in the expense book.
      */
     void setExpense(Expense target, Expense editedExpense);
+
+    void setAliasMap(AliasMap aliasMap);
+
+    AliasMap getAliasMap();
+
+    boolean hasAlias(AliasEntry alias);
+
+    void deleteAlias(AliasEntry alias);
+
+    void addAlias(AliasEntry alias);
+
+    void setAlias(AliasEntry target, AliasEntry editedExpense);
 
     /**
      * Returns an unmodifiable view of the filtered expense list

--- a/src/main/java/seedu/expense/model/ModelManager.java
+++ b/src/main/java/seedu/expense/model/ModelManager.java
@@ -1,19 +1,21 @@
 package seedu.expense.model;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.expense.commons.util.CollectionUtil.requireAllNonNull;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import seedu.expense.commons.core.GuiSettings;
+import seedu.expense.commons.core.LogsCenter;
+import seedu.expense.model.alias.AliasEntry;
+import seedu.expense.model.alias.AliasMap;
+import seedu.expense.model.budget.Budget;
+import seedu.expense.model.expense.Amount;
+import seedu.expense.model.expense.Expense;
 
 import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
-import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
-import seedu.expense.commons.core.GuiSettings;
-import seedu.expense.commons.core.LogsCenter;
-import seedu.expense.model.budget.Budget;
-import seedu.expense.model.expense.Amount;
-import seedu.expense.model.expense.Expense;
+import static java.util.Objects.requireNonNull;
+import static seedu.expense.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * Represents the in-memory model of the expense book data.
@@ -23,13 +25,15 @@ public class ModelManager implements Model {
 
     private final ExpenseBook expenseBook;
     private final UserPrefs userPrefs;
+    private final AliasMap aliasMap;
     private final FilteredList<Expense> filteredExpenses;
     private final Budget budget;
 
     /**
      * Initializes a ModelManager with the given expenseBook and userPrefs.
      */
-    public ModelManager(ReadOnlyExpenseBook expenseBook, ReadOnlyUserPrefs userPrefs) {
+    public ModelManager(ReadOnlyExpenseBook expenseBook, ReadOnlyUserPrefs userPrefs,
+                        AliasMap aliasMap) {
         super();
         requireAllNonNull(expenseBook, userPrefs);
 
@@ -37,12 +41,13 @@ public class ModelManager implements Model {
 
         this.expenseBook = new ExpenseBook(expenseBook);
         this.userPrefs = new UserPrefs(userPrefs);
+        this.aliasMap = new AliasMap(aliasMap);
         filteredExpenses = new FilteredList<>(this.expenseBook.getExpenseList());
         budget = this.expenseBook.getBudget();
     }
 
     public ModelManager() {
-        this(new ExpenseBook(), new UserPrefs());
+        this(new ExpenseBook(), new UserPrefs(), new AliasMap());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -124,6 +129,40 @@ public class ModelManager implements Model {
     @Override
     public void topupBudget(Amount amount) {
         budget.topupBudget(amount);
+    }
+
+    //=========== AliasMap ================================================================================
+
+    @Override
+    public void setAliasMap(AliasMap aliasMap) {
+        this.aliasMap.resetData(aliasMap);
+    }
+
+    @Override
+    public AliasMap getAliasMap() {
+        return aliasMap;
+    }
+
+    @Override
+    public boolean hasAlias(AliasEntry alias) {
+        requireNonNull(alias);
+        return aliasMap.hasAlias(alias);
+    }
+
+    @Override
+    public void deleteAlias(AliasEntry alias) {
+        aliasMap.removeAlias(alias);
+    }
+
+    @Override
+    public void addAlias(AliasEntry alias) {
+        aliasMap.addAlias(alias);
+    }
+
+    @Override
+    public void setAlias(AliasEntry target, AliasEntry editedExpense) {
+        requireAllNonNull(target, editedExpense);
+        aliasMap.setAlias(target, editedExpense);
     }
 
     //=========== Filtered Expense List Accessors =============================================================

--- a/src/main/java/seedu/expense/model/ModelManager.java
+++ b/src/main/java/seedu/expense/model/ModelManager.java
@@ -160,7 +160,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setAlias(AliasEntry target, AliasEntry editedExpense) {
+    public void setAlias(AliasEntry target, AliasEntry editedExpense) throws IllegalArgumentException {
         requireAllNonNull(target, editedExpense);
         aliasMap.setAlias(target, editedExpense);
     }

--- a/src/main/java/seedu/expense/model/ModelManager.java
+++ b/src/main/java/seedu/expense/model/ModelManager.java
@@ -1,5 +1,12 @@
 package seedu.expense.model;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.expense.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.expense.commons.core.GuiSettings;
@@ -9,13 +16,6 @@ import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.budget.Budget;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
-
-import java.nio.file.Path;
-import java.util.function.Predicate;
-import java.util.logging.Logger;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.expense.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * Represents the in-memory model of the expense book data.

--- a/src/main/java/seedu/expense/model/UserPrefs.java
+++ b/src/main/java/seedu/expense/model/UserPrefs.java
@@ -1,12 +1,12 @@
 package seedu.expense.model;
 
-import static java.util.Objects.requireNonNull;
+import seedu.expense.commons.core.GuiSettings;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
-import seedu.expense.commons.core.GuiSettings;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Represents User's preferences.
@@ -15,6 +15,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
     private Path expenseBookFilePath = Paths.get("data", "expensebook.json");
+    private Path aliasMapFilePath = Paths.get("data", "aliasmap.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -50,6 +51,10 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     public Path getExpenseBookFilePath() {
         return expenseBookFilePath;
+    }
+
+    public Path getAliasMapFilePath() {
+        return aliasMapFilePath;
     }
 
     public void setExpenseBookFilePath(Path expenseBookFilePath) {

--- a/src/main/java/seedu/expense/model/UserPrefs.java
+++ b/src/main/java/seedu/expense/model/UserPrefs.java
@@ -1,12 +1,12 @@
 package seedu.expense.model;
 
-import seedu.expense.commons.core.GuiSettings;
+import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
-import static java.util.Objects.requireNonNull;
+import seedu.expense.commons.core.GuiSettings;
 
 /**
  * Represents User's preferences.

--- a/src/main/java/seedu/expense/model/alias/AliasEntry.java
+++ b/src/main/java/seedu/expense/model/alias/AliasEntry.java
@@ -1,0 +1,20 @@
+package seedu.expense.model.alias;
+
+public class AliasEntry {
+    private static final String DUPLICATE_KEYWORD_FOUND = "The %s keyword already exist in your customisation.";
+    private final String key;
+    private final String value;
+
+    public AliasEntry(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return this.key;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/src/main/java/seedu/expense/model/alias/AliasEntry.java
+++ b/src/main/java/seedu/expense/model/alias/AliasEntry.java
@@ -4,6 +4,12 @@ public class AliasEntry {
     private final String key;
     private final String value;
 
+    /**
+     * Constructs an {@code AliasEntry} with specific Key and Value string.
+     *
+     * @param key alias string
+     * @param value default command word
+     */
     public AliasEntry(String key, String value) {
         this.key = key;
         this.value = value;

--- a/src/main/java/seedu/expense/model/alias/AliasEntry.java
+++ b/src/main/java/seedu/expense/model/alias/AliasEntry.java
@@ -16,4 +16,16 @@ public class AliasEntry {
     public String getValue() {
         return this.value;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AliasEntry)) {
+            return false;
+        }
+        return this.key.equals(((AliasEntry) o).key)
+                && this.value.equals(((AliasEntry) o).value);
+    }
 }

--- a/src/main/java/seedu/expense/model/alias/AliasEntry.java
+++ b/src/main/java/seedu/expense/model/alias/AliasEntry.java
@@ -1,7 +1,6 @@
 package seedu.expense.model.alias;
 
 public class AliasEntry {
-    private static final String DUPLICATE_KEYWORD_FOUND = "The %s keyword already exist in your customisation.";
     private final String key;
     private final String value;
 

--- a/src/main/java/seedu/expense/model/alias/AliasMap.java
+++ b/src/main/java/seedu/expense/model/alias/AliasMap.java
@@ -135,4 +135,14 @@ public class AliasMap {
         aliasMap.remove(alias.getKey());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof AliasMap)) {
+            return false;
+        }
+        return this.aliasMap.equals(((AliasMap) o).aliasMap);
+    }
 }

--- a/src/main/java/seedu/expense/model/alias/AliasMap.java
+++ b/src/main/java/seedu/expense/model/alias/AliasMap.java
@@ -1,0 +1,155 @@
+package seedu.expense.model;
+
+import seedu.expense.model.alias.AliasEntry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Wraps all data at the expense-book level
+ * Duplicates are not allowed (by .isSameExpense comparison)
+ */
+public class AliasMap {
+
+
+    private final HashMap<String, String> aliasMap;
+    /*
+    private static final HashMap<String, String> classMap = new HashMap<>();
+    private static final String dir = "seedu.expense.logic.commands.";
+    static {
+        classMap.put(AddCommand.COMMAND_WORD, "AddCommand");
+        classMap.put(ClearCommand.COMMAND_WORD, "ClearCommand");
+        classMap.put(DeleteCommand.COMMAND_WORD, "DeleteCommand");
+        classMap.put(EditCommand.COMMAND_WORD, "EditCommand");
+        classMap.put(ExitCommand.COMMAND_WORD, "ExitCommand");
+        classMap.put(FindCommand.COMMAND_WORD, "FindCommand");
+        classMap.put(HelpCommand.COMMAND_WORD, "AddCommand");
+        classMap.put(ListCommand.COMMAND_WORD, "AddCommand");
+        classMap.put(RemarkCommand.COMMAND_WORD, "AddCommand");
+        classMap.put(TopupCommand.COMMAND_WORD, "AddCommand");
+    }
+     */
+
+    public AliasMap() {
+        aliasMap = new HashMap<>();
+    }
+
+    /**
+     * Creates an AliasMap using the AliasMap in the {@code toBeCopied}
+     */
+    public AliasMap(AliasMap toBeCopied) {
+        this();
+        resetData(toBeCopied);
+    }
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+    {
+        expenses = new UniqueExpenseList();
+    }
+    */
+    //// list overwrite operations
+
+    /**
+     * Replaces the contents of the expense list with {@code expenses}.
+     * {@code expenses} must not contain duplicate expenses.
+     */
+    public void setAliases(List<AliasEntry> aliases) {
+        for (AliasEntry e: aliases) {
+            this.aliasMap.put(e.getKey(), e.getValue());
+        }
+    }
+
+    /**
+     * Resets the existing data of this {@code ExpenseBook} with {@code newData}.
+     */
+    public void resetData(AliasMap newData) {
+        requireNonNull(newData);
+
+        setAliases(newData.getAliasList());
+    }
+
+    //// alias-level operations
+
+    /**
+     * Returns true if a expense with the same identity as {@code expense} exists in the expense book.
+     */
+    public boolean hasAlias(AliasEntry aliasEntry) {
+        requireNonNull(aliasEntry);
+        return this.aliasMap.containsKey(aliasEntry.getKey());
+    }
+
+    /**
+     * Adds a expense to the expense book.
+     * The expense must not already exist in the expense book.
+     */
+    public void addAlias(AliasEntry aliasEntry) {
+        aliasMap.put(aliasEntry.getKey(), aliasEntry.getValue());
+    }
+
+    /**
+     * Replaces the given expense {@code target} in the list with {@code editedExpense}.
+     * {@code target} must exist in the expense book.
+     * The expense identity of {@code editedExpense} must not be the same as another existing
+     * expense in the expense book.
+     */
+    public void setAlias(AliasEntry prev, AliasEntry update) {
+        requireNonNull(prev);
+        requireNonNull(update);
+        assert prev.getValue().equals(update.getValue()) : "The two keywords do not update same command";
+
+        this.aliasMap.remove(prev.getKey());
+        addAlias(update);
+    }
+
+    public List<AliasEntry> getAliasList() {
+        List<AliasEntry> aliases = new ArrayList<>();
+        for (Map.Entry<String, String> e: this.aliasMap.entrySet()) {
+            aliases.add(new AliasEntry(e.getKey(), e.getValue()));
+        }
+        return aliases;
+    }
+
+    /**
+     * Removes {@code key} from this {@code ExpenseBook}.
+     * {@code key} must exist in the expense book.
+     */
+    public void removeAlias(AliasEntry alias) {
+        aliasMap.remove(alias.getKey());
+    }
+
+    /*
+    //// util methods
+
+    @Override
+    public String toString() {
+        return expenses.asUnmodifiableObservableList().size() + " expenses";
+        // TODO: refine later
+    }
+
+    @Override
+    public ObservableList<Expense> getExpenseList() {
+        return expenses.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ExpenseBook // instanceof handles nulls
+                && expenses.equals(((ExpenseBook) other).expenses));
+    }
+
+    @Override
+    public int hashCode() {
+        return expenses.hashCode();
+    }
+     */
+}

--- a/src/main/java/seedu/expense/model/alias/AliasMap.java
+++ b/src/main/java/seedu/expense/model/alias/AliasMap.java
@@ -1,6 +1,4 @@
-package seedu.expense.model;
-
-import seedu.expense.model.alias.AliasEntry;
+package seedu.expense.model.alias;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,7 +12,6 @@ import static java.util.Objects.requireNonNull;
  * Duplicates are not allowed (by .isSameExpense comparison)
  */
 public class AliasMap {
-
 
     private final HashMap<String, String> aliasMap;
     /*
@@ -85,6 +82,16 @@ public class AliasMap {
     public boolean hasAlias(AliasEntry aliasEntry) {
         requireNonNull(aliasEntry);
         return this.aliasMap.containsKey(aliasEntry.getKey());
+    }
+
+    public boolean hasAlias(String aliasString) {
+        requireNonNull(aliasString);
+        return this.aliasMap.containsKey(aliasString);
+    }
+
+    public String getValue(String aliasString) {
+        requireNonNull(aliasString);
+        return this.aliasMap.get(aliasString);
     }
 
     /**

--- a/src/main/java/seedu/expense/model/alias/AliasMap.java
+++ b/src/main/java/seedu/expense/model/alias/AliasMap.java
@@ -1,9 +1,8 @@
 package seedu.expense.model.alias;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import seedu.expense.logic.commands.*;
+
+import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 
@@ -13,23 +12,22 @@ import static java.util.Objects.requireNonNull;
  */
 public class AliasMap {
 
+    public static final String MESSAGE_RESERVED = "The %s keyword is reserved.";
+    public static final String DUPLICATE_KEYWORD_FOUND = "The %s keyword already exists.";
+    public static final String UNCHANGED_ALIAS = "Previous and updated alias must not be the same.";
+
     private final HashMap<String, String> aliasMap;
-    /*
-    private static final HashMap<String, String> classMap = new HashMap<>();
-    private static final String dir = "seedu.expense.logic.commands.";
+    private static final Set<String> RESERVED_KEYWORDS;
     static {
-        classMap.put(AddCommand.COMMAND_WORD, "AddCommand");
-        classMap.put(ClearCommand.COMMAND_WORD, "ClearCommand");
-        classMap.put(DeleteCommand.COMMAND_WORD, "DeleteCommand");
-        classMap.put(EditCommand.COMMAND_WORD, "EditCommand");
-        classMap.put(ExitCommand.COMMAND_WORD, "ExitCommand");
-        classMap.put(FindCommand.COMMAND_WORD, "FindCommand");
-        classMap.put(HelpCommand.COMMAND_WORD, "AddCommand");
-        classMap.put(ListCommand.COMMAND_WORD, "AddCommand");
-        classMap.put(RemarkCommand.COMMAND_WORD, "AddCommand");
-        classMap.put(TopupCommand.COMMAND_WORD, "AddCommand");
+        Set<String> reserved = new HashSet<>();
+        RESERVED_KEYWORDS =
+                Set.of(
+                        AddCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD, ClearCommand.COMMAND_WORD,
+                        EditCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
+                        HelpCommand.COMMAND_WORD, ListCommand.COMMAND_WORD, RemarkCommand.COMMAND_WORD,
+                        TopupCommand.COMMAND_WORD
+                );
     }
-     */
 
     public AliasMap() {
         aliasMap = new HashMap<>();
@@ -43,16 +41,6 @@ public class AliasMap {
         resetData(toBeCopied);
     }
 
-    /*
-     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
-     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
-     *
-     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
-     *   among constructors.
-    {
-        expenses = new UniqueExpenseList();
-    }
-    */
     //// list overwrite operations
 
     /**
@@ -108,11 +96,17 @@ public class AliasMap {
      * The expense identity of {@code editedExpense} must not be the same as another existing
      * expense in the expense book.
      */
-    public void setAlias(AliasEntry prev, AliasEntry update) {
+    public void setAlias(AliasEntry prev, AliasEntry update) throws IllegalArgumentException {
         requireNonNull(prev);
         requireNonNull(update);
-        assert prev.getValue().equals(update.getValue()) : "The two keywords do not update same command";
-
+        assert (!prev.getValue().equals(update.getValue())) :
+                "Must replace the same value (command) alias";
+        if (prev.getKey().equals(update.getKey())) {
+            throw new IllegalArgumentException(UNCHANGED_ALIAS);
+        }
+        if (RESERVED_KEYWORDS.contains(update.getKey()) && !prev.getValue().equals(update.getKey())) {
+            throw new IllegalArgumentException(String.format(MESSAGE_RESERVED, update.getKey()));
+        }
         this.aliasMap.remove(prev.getKey());
         addAlias(update);
     }
@@ -133,30 +127,4 @@ public class AliasMap {
         aliasMap.remove(alias.getKey());
     }
 
-    /*
-    //// util methods
-
-    @Override
-    public String toString() {
-        return expenses.asUnmodifiableObservableList().size() + " expenses";
-        // TODO: refine later
-    }
-
-    @Override
-    public ObservableList<Expense> getExpenseList() {
-        return expenses.asUnmodifiableObservableList();
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof ExpenseBook // instanceof handles nulls
-                && expenses.equals(((ExpenseBook) other).expenses));
-    }
-
-    @Override
-    public int hashCode() {
-        return expenses.hashCode();
-    }
-     */
 }

--- a/src/main/java/seedu/expense/model/alias/AliasMap.java
+++ b/src/main/java/seedu/expense/model/alias/AliasMap.java
@@ -1,10 +1,23 @@
 package seedu.expense.model.alias;
 
-import seedu.expense.logic.commands.*;
-
-import java.util.*;
-
 import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import seedu.expense.logic.commands.AddCommand;
+import seedu.expense.logic.commands.ClearCommand;
+import seedu.expense.logic.commands.DeleteCommand;
+import seedu.expense.logic.commands.EditCommand;
+import seedu.expense.logic.commands.ExitCommand;
+import seedu.expense.logic.commands.FindCommand;
+import seedu.expense.logic.commands.HelpCommand;
+import seedu.expense.logic.commands.ListCommand;
+import seedu.expense.logic.commands.RemarkCommand;
+import seedu.expense.logic.commands.TopupCommand;
 
 /**
  * Wraps all data at the expense-book level
@@ -16,9 +29,10 @@ public class AliasMap {
     public static final String DUPLICATE_KEYWORD_FOUND = "The [%s] keyword already exists.";
     public static final String UNCHANGED_ALIAS = "Previous and updated alias must not be the same.";
     public static final String ALIAS_NOT_FOUND = "The [%s] alias cannot be found.";
+    private static final Set<String> RESERVED_KEYWORDS;
 
     private final HashMap<String, String> aliasMap;
-    private static final Set<String> RESERVED_KEYWORDS;
+
     static {
         RESERVED_KEYWORDS =
                 Set.of(
@@ -29,6 +43,9 @@ public class AliasMap {
                 );
     }
 
+    /**
+     * Constructs a new {@code AliasMap}.
+     */
     public AliasMap() {
         aliasMap = new HashMap<>();
     }
@@ -44,8 +61,8 @@ public class AliasMap {
     //// list overwrite operations
 
     /**
-     * Replaces the contents of the expense list with {@code expenses}.
-     * {@code expenses} must not contain duplicate expenses.
+     * Replaces the contents of the alias list with {@code aliases}.
+     * {@code aliases} must not contain duplicate expenses.
      */
     public void setAliases(List<AliasEntry> aliases) {
         for (AliasEntry e: aliases) {
@@ -54,7 +71,7 @@ public class AliasMap {
     }
 
     /**
-     * Resets the existing data of this {@code ExpenseBook} with {@code newData}.
+     * Resets the existing data of this {@code AliasMap} with {@code newData}.
      */
     public void resetData(AliasMap newData) {
         requireNonNull(newData);
@@ -65,13 +82,16 @@ public class AliasMap {
     //// alias-level operations
 
     /**
-     * Returns true if a expense with the same identity as {@code expense} exists in the expense book.
+     * Returns true if an AliasEntry with the same identity as {@code aliasEntry} exists in the alias map.
      */
     public boolean hasAlias(AliasEntry aliasEntry) {
         requireNonNull(aliasEntry);
         return this.aliasMap.containsKey(aliasEntry.getKey());
     }
 
+    /**
+     * Returns true if a String with the same identity as {@code aliasString} exists in the alias map.
+     */
     public boolean hasAlias(String aliasString) {
         requireNonNull(aliasString);
         return this.aliasMap.containsKey(aliasString);
@@ -86,18 +106,18 @@ public class AliasMap {
     }
 
     /**
-     * Adds a expense to the expense book.
-     * The expense must not already exist in the expense book.
+     * Adds an AliasEntry to the alias map.
+     * The entry must not already exist in the alias map.
      */
     public void addAlias(AliasEntry aliasEntry) {
         aliasMap.put(aliasEntry.getKey(), aliasEntry.getValue());
     }
 
     /**
-     * Replaces the given expense {@code target} in the list with {@code editedExpense}.
-     * {@code target} must exist in the expense book.
-     * The expense identity of {@code editedExpense} must not be the same as another existing
-     * expense in the expense book.
+     * Replaces the given etnry {@code prev} in the list with {@code update}.
+     * {@code prev} must exist in the expense book.
+     * The alias of {@code update} must not be the same as another existing
+     * alias in the alias map.
      */
     public void setAlias(AliasEntry prev, AliasEntry update) throws IllegalArgumentException {
         requireNonNull(prev);
@@ -128,8 +148,8 @@ public class AliasMap {
     }
 
     /**
-     * Removes {@code key} from this {@code ExpenseBook}.
-     * {@code key} must exist in the expense book.
+     * Removes {@code alias} from this {@code AliasMap}.
+     * {@code alias} must exist in the expense book.
      */
     public void removeAlias(AliasEntry alias) {
         aliasMap.remove(alias.getKey());

--- a/src/main/java/seedu/expense/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/expense/model/util/SampleDataUtil.java
@@ -1,17 +1,15 @@
 package seedu.expense.model.util;
 
+import seedu.expense.model.ExpenseBook;
+import seedu.expense.model.ReadOnlyExpenseBook;
+import seedu.expense.model.alias.AliasEntry;
+import seedu.expense.model.alias.AliasMap;
+import seedu.expense.model.expense.*;
+import seedu.expense.model.tag.Tag;
+
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import seedu.expense.model.ExpenseBook;
-import seedu.expense.model.ReadOnlyExpenseBook;
-import seedu.expense.model.expense.Amount;
-import seedu.expense.model.expense.Date;
-import seedu.expense.model.expense.Description;
-import seedu.expense.model.expense.Expense;
-import seedu.expense.model.expense.Remark;
-import seedu.expense.model.tag.Tag;
 
 /**
  * Contains utility methods for populating {@code ExpenseBook} with sample data.
@@ -62,6 +60,13 @@ public class SampleDataUtil {
             sampleAb.addExpense(sampleExpense);
         }
         return sampleAb;
+    }
+
+    public static AliasMap getSampleAliasMap() {
+        AliasMap sampleMap = new AliasMap();
+
+        sampleMap.addAlias(new AliasEntry("get", "find"));
+        return sampleMap;
     }
 
     /**

--- a/src/main/java/seedu/expense/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/expense/model/util/SampleDataUtil.java
@@ -1,15 +1,19 @@
 package seedu.expense.model.util;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.alias.AliasEntry;
 import seedu.expense.model.alias.AliasMap;
-import seedu.expense.model.expense.*;
+import seedu.expense.model.expense.Amount;
+import seedu.expense.model.expense.Date;
+import seedu.expense.model.expense.Description;
+import seedu.expense.model.expense.Expense;
+import seedu.expense.model.expense.Remark;
 import seedu.expense.model.tag.Tag;
-
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Contains utility methods for populating {@code ExpenseBook} with sample data.

--- a/src/main/java/seedu/expense/storage/JsonAdaptedAliasEntry.java
+++ b/src/main/java/seedu/expense/storage/JsonAdaptedAliasEntry.java
@@ -22,8 +22,8 @@ class JsonAdaptedAliasEntry {
      * Constructs a {@code JsonAdaptedAliasEntry} with the given expense details.
      */
     @JsonCreator
-    public JsonAdaptedAliasEntry(@JsonProperty("key") String customisedCommandWord,
-                              @JsonProperty("value") String defaultCommandWord) {
+    public JsonAdaptedAliasEntry(@JsonProperty("customisedCommandWord") String customisedCommandWord,
+                              @JsonProperty("defaultCommandWord") String defaultCommandWord) {
         this.customisedCommandWord = customisedCommandWord;
         this.defaultCommandWord = defaultCommandWord;
     }

--- a/src/main/java/seedu/expense/storage/JsonAdaptedAliasEntry.java
+++ b/src/main/java/seedu/expense/storage/JsonAdaptedAliasEntry.java
@@ -1,0 +1,54 @@
+package seedu.expense.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import seedu.expense.commons.exceptions.IllegalValueException;
+import seedu.expense.model.alias.AliasEntry;
+
+import static java.util.Objects.requireNonNull;
+
+
+/**
+ * Jackson-friendly version of {@link AliasEntry}.
+ */
+class JsonAdaptedAliasEntry {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "AliasEntry's %s field is missing!";
+
+    private final String customisedCommandWord;
+    private final String defaultCommandWord;
+
+    /**
+     * Constructs a {@code JsonAdaptedAliasEntry} with the given expense details.
+     */
+    @JsonCreator
+    public JsonAdaptedAliasEntry(@JsonProperty("key") String customisedCommandWord,
+                              @JsonProperty("value") String defaultCommandWord) {
+        this.customisedCommandWord = customisedCommandWord;
+        this.defaultCommandWord = defaultCommandWord;
+    }
+
+    /**
+     * Converts a given {@code Expense} into this class for Jackson use.
+     */
+    public JsonAdaptedAliasEntry(AliasEntry entry) {
+        customisedCommandWord = entry.getKey();
+        defaultCommandWord = entry.getValue();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted alias entry into the model's {@code AliasEntry} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted alias entry.
+     */
+    public AliasEntry toModelType() { // throws IllegalValueException {
+        requireNonNull(customisedCommandWord);
+        requireNonNull(defaultCommandWord);
+
+        assert !customisedCommandWord.isEmpty() : "Custom keyword cannot be empty!";
+        assert !defaultCommandWord.isEmpty() : "Default keyword cannot be empty!";
+
+        return new AliasEntry(customisedCommandWord, defaultCommandWord);
+    }
+
+}

--- a/src/main/java/seedu/expense/storage/JsonAdaptedAliasEntry.java
+++ b/src/main/java/seedu/expense/storage/JsonAdaptedAliasEntry.java
@@ -1,11 +1,12 @@
 package seedu.expense.storage;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import seedu.expense.commons.exceptions.IllegalValueException;
 import seedu.expense.model.alias.AliasEntry;
-
-import static java.util.Objects.requireNonNull;
 
 
 /**

--- a/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
+++ b/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
@@ -1,0 +1,78 @@
+package seedu.expense.storage;
+
+import seedu.expense.commons.core.LogsCenter;
+import seedu.expense.commons.exceptions.DataConversionException;
+import seedu.expense.commons.exceptions.IllegalValueException;
+import seedu.expense.commons.util.FileUtil;
+import seedu.expense.commons.util.JsonUtil;
+import seedu.expense.model.AliasMap;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A class to access ExpenseBook data stored as a json file on the hard disk.
+ */
+public class JsonAliasMapStorage {
+
+    private static final Logger logger = LogsCenter.getLogger(JsonAliasMapStorage.class);
+
+    private Path filePath;
+
+    public JsonAliasMapStorage(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    public Path getAliasMapFilePath() {
+        return filePath;
+    }
+
+    public Optional<AliasMap> readAliasMap() throws DataConversionException {
+        return readAliasMap(filePath);
+    }
+
+    /**
+     * Read and create an Optional of AliasMap from JSON at specified filepath.
+     *
+     * @param filePath location of the data. Cannot be null.
+     * @throws DataConversionException if the file is not in the correct format.
+     */
+    public Optional<AliasMap> readAliasMap(Path filePath) throws DataConversionException {
+        requireNonNull(filePath);
+
+        Optional<JsonSerializableAliasMap> jsonAliasMap = JsonUtil.readJsonFile(
+                filePath, JsonSerializableAliasMap.class);
+        if (!jsonAliasMap.isPresent()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(jsonAliasMap.get().toModelType());
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+            throw new DataConversionException(ive);
+        }
+    }
+
+    public void saveAliasMap(AliasMap aliasMap) throws IOException {
+        saveAliasMap(aliasMap, filePath);
+    }
+
+    /**
+     * Save AliasMap as JSON in specified filepath.
+     *
+     * @param filePath location of the data. Cannot be null.
+     */
+    public void saveAliasMap(AliasMap aliasMap, Path filePath) throws IOException {
+        requireNonNull(aliasMap);
+        requireNonNull(filePath);
+
+        FileUtil.createIfMissing(filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableAliasMap(aliasMap), filePath);
+    }
+
+}

--- a/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
+++ b/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A class to access ExpenseBook data stored as a json file on the hard disk.
+ * A class to access AliasMap data stored as a json file on the hard disk.
  */
 public class JsonAliasMapStorage {
 

--- a/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
+++ b/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
@@ -1,18 +1,18 @@
 package seedu.expense.storage;
 
-import seedu.expense.commons.core.LogsCenter;
-import seedu.expense.commons.exceptions.DataConversionException;
-import seedu.expense.commons.exceptions.IllegalValueException;
-import seedu.expense.commons.util.FileUtil;
-import seedu.expense.commons.util.JsonUtil;
-import seedu.expense.model.alias.AliasMap;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import static java.util.Objects.requireNonNull;
+import seedu.expense.commons.core.LogsCenter;
+import seedu.expense.commons.exceptions.DataConversionException;
+import seedu.expense.commons.exceptions.IllegalValueException;
+import seedu.expense.commons.util.FileUtil;
+import seedu.expense.commons.util.JsonUtil;
+import seedu.expense.model.alias.AliasMap;
 
 /**
  * A class to access AliasMap data stored as a json file on the hard disk.

--- a/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
+++ b/src/main/java/seedu/expense/storage/JsonAliasMapStorage.java
@@ -5,7 +5,7 @@ import seedu.expense.commons.exceptions.DataConversionException;
 import seedu.expense.commons.exceptions.IllegalValueException;
 import seedu.expense.commons.util.FileUtil;
 import seedu.expense.commons.util.JsonUtil;
-import seedu.expense.model.AliasMap;
+import seedu.expense.model.alias.AliasMap;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
+++ b/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
@@ -1,0 +1,48 @@
+package seedu.expense.storage;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import seedu.expense.commons.exceptions.IllegalValueException;
+import seedu.expense.model.AliasMap;
+import seedu.expense.model.alias.AliasEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JsonSerializableAliasMap {
+    public static final String MESSAGE_DUPLICATE_ALIAS = "Alias list contains duplicate alias(es).";
+    private final List<JsonAdaptedAliasEntry> aliases = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonSerializableAliasMap} with the given alias entries.
+     */
+    public JsonSerializableAliasMap(@JsonProperty("aliasMap") List<JsonAdaptedAliasEntry> entries) {
+        this.aliases.addAll(entries);
+    }
+
+    /**
+     * Converts a given {@code AliasMap} into this class for Jackson use.
+     *
+     * @param source future changes to this will not affect the created {@code JsonSerializableAliasMap}.
+     */
+    public JsonSerializableAliasMap(AliasMap source) {
+        aliases.addAll(source.getAliasList().stream().map(JsonAdaptedAliasEntry::new).collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this alias map into the model's {@code AliasMap} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated.
+     */
+    public AliasMap toModelType() throws IllegalValueException {
+        AliasMap aliasMap = new AliasMap();
+        for (JsonAdaptedAliasEntry jsonAdaptedAliasEntry : aliases) {
+            AliasEntry alias = jsonAdaptedAliasEntry.toModelType();
+            if (aliasMap.hasAlias(alias)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_ALIAS);
+            }
+            aliasMap.addAlias(alias);
+        }
+        return aliasMap;
+    }
+}

--- a/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
+++ b/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
@@ -1,13 +1,14 @@
 package seedu.expense.storage;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import seedu.expense.commons.exceptions.IllegalValueException;
-import seedu.expense.model.alias.AliasMap;
-import seedu.expense.model.alias.AliasEntry;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.expense.commons.exceptions.IllegalValueException;
+import seedu.expense.model.alias.AliasEntry;
+import seedu.expense.model.alias.AliasMap;
 
 public class JsonSerializableAliasMap {
     public static final String MESSAGE_DUPLICATE_ALIAS = "Alias list contains duplicate alias(es).";

--- a/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
+++ b/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
@@ -16,7 +16,7 @@ public class JsonSerializableAliasMap {
     /**
      * Constructs a {@code JsonSerializableAliasMap} with the given alias entries.
      */
-    public JsonSerializableAliasMap(@JsonProperty("aliasMap") List<JsonAdaptedAliasEntry> entries) {
+    public JsonSerializableAliasMap(@JsonProperty("aliases") List<JsonAdaptedAliasEntry> entries) {
         this.aliases.addAll(entries);
     }
 

--- a/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
+++ b/src/main/java/seedu/expense/storage/JsonSerializableAliasMap.java
@@ -2,7 +2,7 @@ package seedu.expense.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import seedu.expense.commons.exceptions.IllegalValueException;
-import seedu.expense.model.AliasMap;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.alias.AliasEntry;
 
 import java.util.ArrayList;

--- a/src/main/java/seedu/expense/storage/Storage.java
+++ b/src/main/java/seedu/expense/storage/Storage.java
@@ -1,7 +1,7 @@
 package seedu.expense.storage;
 
 import seedu.expense.commons.exceptions.DataConversionException;
-import seedu.expense.model.AliasMap;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.ReadOnlyUserPrefs;
 import seedu.expense.model.UserPrefs;

--- a/src/main/java/seedu/expense/storage/Storage.java
+++ b/src/main/java/seedu/expense/storage/Storage.java
@@ -1,14 +1,14 @@
 package seedu.expense.storage;
 
-import seedu.expense.commons.exceptions.DataConversionException;
-import seedu.expense.model.alias.AliasMap;
-import seedu.expense.model.ReadOnlyExpenseBook;
-import seedu.expense.model.ReadOnlyUserPrefs;
-import seedu.expense.model.UserPrefs;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
+
+import seedu.expense.commons.exceptions.DataConversionException;
+import seedu.expense.model.ReadOnlyExpenseBook;
+import seedu.expense.model.ReadOnlyUserPrefs;
+import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 
 /**
  * API of the Storage component

--- a/src/main/java/seedu/expense/storage/Storage.java
+++ b/src/main/java/seedu/expense/storage/Storage.java
@@ -1,13 +1,14 @@
 package seedu.expense.storage;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Optional;
-
 import seedu.expense.commons.exceptions.DataConversionException;
+import seedu.expense.model.AliasMap;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.ReadOnlyUserPrefs;
 import seedu.expense.model.UserPrefs;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * API of the Storage component
@@ -29,4 +30,13 @@ public interface Storage extends ExpenseBookStorage, UserPrefsStorage {
     @Override
     void saveExpenseBook(ReadOnlyExpenseBook expenseBook) throws IOException;
 
+    Path getAliasMapFilePath();
+
+    Optional<AliasMap> readAliasMap() throws DataConversionException, IOException;
+
+    Optional<AliasMap> readAliasMap(Path filePath) throws DataConversionException, IOException;
+
+    void saveAliasMap(AliasMap aliasMap) throws IOException;
+
+    void saveAliasMap(AliasMap aliasMap, Path filePath) throws IOException;
 }

--- a/src/main/java/seedu/expense/storage/StorageManager.java
+++ b/src/main/java/seedu/expense/storage/StorageManager.java
@@ -2,10 +2,10 @@ package seedu.expense.storage;
 
 import seedu.expense.commons.core.LogsCenter;
 import seedu.expense.commons.exceptions.DataConversionException;
-import seedu.expense.model.AliasMap;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.ReadOnlyUserPrefs;
 import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/main/java/seedu/expense/storage/StorageManager.java
+++ b/src/main/java/seedu/expense/storage/StorageManager.java
@@ -1,15 +1,16 @@
 package seedu.expense.storage;
 
+import seedu.expense.commons.core.LogsCenter;
+import seedu.expense.commons.exceptions.DataConversionException;
+import seedu.expense.model.AliasMap;
+import seedu.expense.model.ReadOnlyExpenseBook;
+import seedu.expense.model.ReadOnlyUserPrefs;
+import seedu.expense.model.UserPrefs;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
-
-import seedu.expense.commons.core.LogsCenter;
-import seedu.expense.commons.exceptions.DataConversionException;
-import seedu.expense.model.ReadOnlyExpenseBook;
-import seedu.expense.model.ReadOnlyUserPrefs;
-import seedu.expense.model.UserPrefs;
 
 /**
  * Manages storage of ExpenseBook data in local storage.
@@ -19,14 +20,17 @@ public class StorageManager implements Storage {
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private ExpenseBookStorage expenseBookStorage;
     private UserPrefsStorage userPrefsStorage;
+    private JsonAliasMapStorage aliasMapStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code ExpenseBookStorage} and {@code UserPrefStorage}.
      */
-    public StorageManager(ExpenseBookStorage expenseBookStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(ExpenseBookStorage expenseBookStorage, UserPrefsStorage userPrefsStorage,
+                          JsonAliasMapStorage aliasMapStorage) {
         super();
         this.expenseBookStorage = expenseBookStorage;
         this.userPrefsStorage = userPrefsStorage;
+        this.aliasMapStorage = aliasMapStorage;
     }
 
     // ================ UserPrefs methods ==============================
@@ -74,6 +78,35 @@ public class StorageManager implements Storage {
     public void saveExpenseBook(ReadOnlyExpenseBook expenseBook, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);
         expenseBookStorage.saveExpenseBook(expenseBook, filePath);
+    }
+
+    // ================ AliasMap methods ==============================
+
+    @Override
+    public Path getAliasMapFilePath() {
+        return aliasMapStorage.getAliasMapFilePath();
+    }
+
+    @Override
+    public Optional<AliasMap> readAliasMap() throws DataConversionException, IOException {
+        return readAliasMap(aliasMapStorage.getAliasMapFilePath());
+    }
+
+    @Override
+    public Optional<AliasMap> readAliasMap(Path filePath) throws DataConversionException, IOException {
+        logger.fine("Attempting to read data from file: " + filePath);
+        return aliasMapStorage.readAliasMap(filePath);
+    }
+
+    @Override
+    public void saveAliasMap(AliasMap aliasMap) throws IOException {
+        saveAliasMap(aliasMap, aliasMapStorage.getAliasMapFilePath());
+    }
+
+    @Override
+    public void saveAliasMap(AliasMap aliasMap, Path filePath) throws IOException {
+        logger.fine("Attempting to write to data file: " + filePath);
+        aliasMapStorage.saveAliasMap(aliasMap, filePath);
     }
 
 }

--- a/src/main/java/seedu/expense/storage/StorageManager.java
+++ b/src/main/java/seedu/expense/storage/StorageManager.java
@@ -1,16 +1,16 @@
 package seedu.expense.storage;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
 import seedu.expense.commons.core.LogsCenter;
 import seedu.expense.commons.exceptions.DataConversionException;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.ReadOnlyUserPrefs;
 import seedu.expense.model.UserPrefs;
 import seedu.expense.model.alias.AliasMap;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.logging.Logger;
 
 /**
  * Manages storage of ExpenseBook data in local storage.

--- a/src/main/resources/view/BudgetDisplay.fxml
+++ b/src/main/resources/view/BudgetDisplay.fxml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.StackPane?>
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ProgressBar?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.geometry.Insets?>
-
+<?import javafx.scene.layout.StackPane?>
 <HBox fx:id="budgetPlaceHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
       xmlns:fx="http://javafx.com/fxml/1">
   <padding>

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
-
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
 </StackPane>

--- a/src/main/resources/view/ExpenseListCard.fxml
+++ b/src/main/resources/view/ExpenseListCard.fxml
@@ -5,7 +5,6 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
-
 <?import javafx.scene.layout.RowConstraints?>
 <GridPane id="cardPane" fx:id="cardPane" hgap="30" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>

--- a/src/main/resources/view/ExpenseListPanel.fxml
+++ b/src/main/resources/view/ExpenseListPanel.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
-
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="expenseListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.Scene?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.Scene?>
 <?import javafx.stage.Stage?>
-
 <fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -2,15 +2,14 @@
 
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.Scene?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
+<?import javafx.scene.Scene?>
+<?import javafx.stage.Stage?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="Bamboo" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -2,8 +2,7 @@
 
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
-
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
-    xmlns:fx="http://javafx.com/fxml/1">
+           xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
 </StackPane>

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
-
 <GridPane styleClass="status-bar" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10" />

--- a/src/test/java/seedu/expense/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/expense/logic/LogicManagerTest.java
@@ -1,21 +1,8 @@
 package seedu.expense.logic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX;
-import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.expense.logic.commands.CommandTestUtil.AMOUNT_DESC_FOOD;
-import static seedu.expense.logic.commands.CommandTestUtil.DATE_DESC_FOOD;
-import static seedu.expense.logic.commands.CommandTestUtil.DESCRIPTION_DESC_FOOD;
-import static seedu.expense.testutil.Assert.assertThrows;
-import static seedu.expense.testutil.TypicalExpenses.FOOD;
-
-import java.io.IOException;
-import java.nio.file.Path;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
 import seedu.expense.logic.commands.AddCommand;
 import seedu.expense.logic.commands.CommandResult;
 import seedu.expense.logic.commands.ListCommand;
@@ -25,11 +12,23 @@ import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
+import seedu.expense.storage.JsonAliasMapStorage;
 import seedu.expense.storage.JsonExpenseBookStorage;
 import seedu.expense.storage.JsonUserPrefsStorage;
 import seedu.expense.storage.StorageManager;
 import seedu.expense.testutil.ExpenseBuilder;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX;
+import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.expense.logic.commands.CommandTestUtil.*;
+import static seedu.expense.testutil.Assert.assertThrows;
+import static seedu.expense.testutil.TypicalExpenses.FOOD;
 
 public class LogicManagerTest {
     private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy exception");
@@ -45,7 +44,8 @@ public class LogicManagerTest {
         JsonExpenseBookStorage expenseBookStorage =
                 new JsonExpenseBookStorage(temporaryFolder.resolve("expenseBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        StorageManager storage = new StorageManager(expenseBookStorage, userPrefsStorage);
+        JsonAliasMapStorage aliasMapStorage = new JsonAliasMapStorage(temporaryFolder.resolve("aliasMap.json"));
+        StorageManager storage = new StorageManager(expenseBookStorage, userPrefsStorage, aliasMapStorage);
         logic = new LogicManager(model, storage);
     }
 
@@ -74,7 +74,9 @@ public class LogicManagerTest {
                 new JsonExpenseBookIoExceptionThrowingStub(temporaryFolder.resolve("ioExceptionExpenseBook.json"));
         JsonUserPrefsStorage userPrefsStorage =
                 new JsonUserPrefsStorage(temporaryFolder.resolve("ioExceptionUserPrefs.json"));
-        StorageManager storage = new StorageManager(expenseBookStorage, userPrefsStorage);
+        JsonAliasMapStorage aliasMapStorage =
+                new JsonAliasMapStorage(temporaryFolder.resolve("ioExceptionAliasMap.json"));
+        StorageManager storage = new StorageManager(expenseBookStorage, userPrefsStorage, aliasMapStorage);
         logic = new LogicManager(model, storage);
 
         // Execute add command
@@ -127,7 +129,7 @@ public class LogicManagerTest {
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
             String expectedMessage) {
-        Model expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs(), new AliasMap());
         assertCommandFailure(inputCommand, expectedException, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/expense/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/expense/logic/LogicManagerTest.java
@@ -1,8 +1,21 @@
 package seedu.expense.logic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX;
+import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.expense.logic.commands.CommandTestUtil.AMOUNT_DESC_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.DATE_DESC_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.DESCRIPTION_DESC_FOOD;
+import static seedu.expense.testutil.Assert.assertThrows;
+import static seedu.expense.testutil.TypicalExpenses.FOOD;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
 import seedu.expense.logic.commands.AddCommand;
 import seedu.expense.logic.commands.CommandResult;
 import seedu.expense.logic.commands.ListCommand;
@@ -19,16 +32,6 @@ import seedu.expense.storage.JsonExpenseBookStorage;
 import seedu.expense.storage.JsonUserPrefsStorage;
 import seedu.expense.storage.StorageManager;
 import seedu.expense.testutil.ExpenseBuilder;
-
-import java.io.IOException;
-import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX;
-import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.expense.logic.commands.CommandTestUtil.*;
-import static seedu.expense.testutil.Assert.assertThrows;
-import static seedu.expense.testutil.TypicalExpenses.FOOD;
 
 public class LogicManagerTest {
     private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy exception");

--- a/src/test/java/seedu/expense/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AddCommandIntegrationTest.java
@@ -1,17 +1,17 @@
 package seedu.expense.logic.commands;
 
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.testutil.ExpenseBuilder;
+
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
@@ -22,14 +22,14 @@ public class AddCommandIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
+        model = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
     }
 
     @Test
     public void execute_newExpense_success() {
         Expense validExpense = new ExpenseBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs(), new AliasMap());
         expectedModel.addExpense(validExpense);
 
         assertCommandSuccess(new AddCommand(validExpense), model,

--- a/src/test/java/seedu/expense/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AddCommandIntegrationTest.java
@@ -1,17 +1,18 @@
 package seedu.expense.logic.commands;
 
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
 import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.testutil.ExpenseBuilder;
-
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.

--- a/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
@@ -1,29 +1,28 @@
 package seedu.expense.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.testutil.Assert.assertThrows;
-
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.function.Predicate;
-
-import org.junit.jupiter.api.Test;
-
 import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.logic.commands.exceptions.CommandException;
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.Model;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.ReadOnlyUserPrefs;
+import seedu.expense.model.alias.AliasEntry;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.budget.Budget;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.testutil.ExpenseBuilder;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.expense.testutil.Assert.assertThrows;
 
 public class AddCommandTest {
 
@@ -157,6 +156,36 @@ public class AddCommandTest {
 
         @Override
         public void topupBudget(Amount amount) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAlias(AliasEntry prev, AliasEntry curr) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAliasMap(AliasMap map) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addAlias(AliasEntry entry) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public AliasMap getAliasMap() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasAlias(AliasEntry entry) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteAlias(AliasEntry entry) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
@@ -1,7 +1,19 @@
 package seedu.expense.logic.commands;
 
-import javafx.collections.ObservableList;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.logic.commands.exceptions.CommandException;
 import seedu.expense.model.ExpenseBook;
@@ -14,15 +26,6 @@ import seedu.expense.model.budget.Budget;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.testutil.ExpenseBuilder;
-
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.function.Predicate;
-
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.expense.testutil.Assert.assertThrows;
 
 public class AddCommandTest {
 

--- a/src/test/java/seedu/expense/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/ClearCommandTest.java
@@ -1,14 +1,15 @@
 package seedu.expense.logic.commands;
 
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
 import seedu.expense.model.alias.AliasMap;
-
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 
 public class ClearCommandTest {
 

--- a/src/test/java/seedu/expense/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/ClearCommandTest.java
@@ -1,14 +1,14 @@
 package seedu.expense.logic.commands;
 
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-
 import org.junit.jupiter.api.Test;
-
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
+
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 
 public class ClearCommandTest {
 
@@ -22,8 +22,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyExpenseBook_success() {
-        Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
+        Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
         expectedModel.setExpenseBook(new ExpenseBook());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/seedu/expense/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/DeleteCommandTest.java
@@ -1,6 +1,16 @@
 package seedu.expense.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.expense.commons.core.Messages;
 import seedu.expense.commons.core.index.Index;
 import seedu.expense.model.Model;
@@ -8,13 +18,6 @@ import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
 import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.logic.commands.CommandTestUtil.*;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for

--- a/src/test/java/seedu/expense/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/DeleteCommandTest.java
@@ -1,22 +1,20 @@
 package seedu.expense.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
-
 import org.junit.jupiter.api.Test;
-
 import seedu.expense.commons.core.Messages;
 import seedu.expense.commons.core.index.Index;
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.logic.commands.CommandTestUtil.*;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -24,7 +22,7 @@ import seedu.expense.model.expense.Expense;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -33,7 +31,7 @@ public class DeleteCommandTest {
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EXPENSE_SUCCESS, expenseToDelete);
 
-        ModelManager expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs(), new AliasMap());
         expectedModel.deleteExpense(expenseToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
@@ -56,7 +54,7 @@ public class DeleteCommandTest {
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EXPENSE_SUCCESS, expenseToDelete);
 
-        Model expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs(), new AliasMap());
         expectedModel.deleteExpense(expenseToDelete);
         showNoExpense(expectedModel);
 

--- a/src/test/java/seedu/expense/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/EditCommandTest.java
@@ -1,6 +1,21 @@
 package seedu.expense.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.logic.commands.CommandTestUtil.DESC_BUS;
+import static seedu.expense.logic.commands.CommandTestUtil.DESC_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_AMOUNT_BUS;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BUS;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_TAG_TRANSPORT;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.expense.commons.core.Messages;
 import seedu.expense.commons.core.index.Index;
 import seedu.expense.logic.commands.EditCommand.EditExpenseDescriptor;
@@ -12,13 +27,6 @@ import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.testutil.EditExpenseDescriptorBuilder;
 import seedu.expense.testutil.ExpenseBuilder;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.logic.commands.CommandTestUtil.*;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
@@ -37,7 +45,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()),
+                new UserPrefs(), new AliasMap());
         expectedModel.setExpense(model.getFilteredExpenseList().get(0), editedExpense);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -59,7 +68,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()),
+                new UserPrefs(), new AliasMap());
         expectedModel.setExpense(lastExpense, editedExpense);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -72,7 +82,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()),
+                new UserPrefs(), new AliasMap());
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -89,7 +100,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()),
+                new UserPrefs(), new AliasMap());
         expectedModel.setExpense(model.getFilteredExpenseList().get(0), editedExpense);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/expense/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/EditCommandTest.java
@@ -1,21 +1,6 @@
 package seedu.expense.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.logic.commands.CommandTestUtil.DESC_BUS;
-import static seedu.expense.logic.commands.CommandTestUtil.DESC_FOOD;
-import static seedu.expense.logic.commands.CommandTestUtil.VALID_AMOUNT_BUS;
-import static seedu.expense.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BUS;
-import static seedu.expense.logic.commands.CommandTestUtil.VALID_TAG_TRANSPORT;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
-
 import org.junit.jupiter.api.Test;
-
 import seedu.expense.commons.core.Messages;
 import seedu.expense.commons.core.index.Index;
 import seedu.expense.logic.commands.EditCommand.EditExpenseDescriptor;
@@ -23,16 +8,24 @@ import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.testutil.EditExpenseDescriptorBuilder;
 import seedu.expense.testutil.ExpenseBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.logic.commands.CommandTestUtil.*;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -44,7 +37,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
         expectedModel.setExpense(model.getFilteredExpenseList().get(0), editedExpense);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -66,7 +59,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
         expectedModel.setExpense(lastExpense, editedExpense);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -79,7 +72,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -96,7 +89,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
         expectedModel.setExpense(model.getFilteredExpenseList().get(0), editedExpense);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/expense/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/FindCommandTest.java
@@ -1,6 +1,20 @@
 package seedu.expense.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.commons.core.Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.testutil.TypicalExpenses.PHONE_BILL;
+import static seedu.expense.testutil.TypicalExpenses.SWEE_CHOON;
+import static seedu.expense.testutil.TypicalExpenses.ZARA;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
@@ -8,14 +22,6 @@ import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.DateMatchesPredicate;
 import seedu.expense.model.expense.NameContainsKeywordsPredicate;
 import seedu.expense.model.expense.TagsMatchesPredicate;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.expense.commons.core.Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.testutil.TypicalExpenses.*;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.

--- a/src/test/java/seedu/expense/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/FindCommandTest.java
@@ -1,33 +1,28 @@
 package seedu.expense.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.commons.core.Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.testutil.TypicalExpenses.PHONE_BILL;
-import static seedu.expense.testutil.TypicalExpenses.SWEE_CHOON;
-import static seedu.expense.testutil.TypicalExpenses.ZARA;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+import org.junit.jupiter.api.Test;
+import seedu.expense.model.Model;
+import seedu.expense.model.ModelManager;
+import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
+import seedu.expense.model.expense.DateMatchesPredicate;
+import seedu.expense.model.expense.NameContainsKeywordsPredicate;
+import seedu.expense.model.expense.TagsMatchesPredicate;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
-
-import seedu.expense.model.Model;
-import seedu.expense.model.ModelManager;
-import seedu.expense.model.UserPrefs;
-import seedu.expense.model.expense.DateMatchesPredicate;
-import seedu.expense.model.expense.NameContainsKeywordsPredicate;
-import seedu.expense.model.expense.TagsMatchesPredicate;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.expense.commons.core.Messages.MESSAGE_EXPENSES_LISTED_OVERVIEW;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.testutil.TypicalExpenses.*;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
+    private Model expectedModel = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/expense/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/ListCommandTest.java
@@ -1,16 +1,17 @@
 package seedu.expense.logic.commands;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import seedu.expense.model.Model;
-import seedu.expense.model.ModelManager;
-import seedu.expense.model.UserPrefs;
-import seedu.expense.model.alias.AliasMap;
-
 import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
 import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.expense.model.Model;
+import seedu.expense.model.ModelManager;
+import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.

--- a/src/test/java/seedu/expense/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/ListCommandTest.java
@@ -1,16 +1,16 @@
 package seedu.expense.logic.commands;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.expense.model.Model;
+import seedu.expense.model.ModelManager;
+import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
+
 import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
 import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import seedu.expense.model.Model;
-import seedu.expense.model.ModelManager;
-import seedu.expense.model.UserPrefs;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -22,8 +22,8 @@ public class ListCommandTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs());
+        model = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
+        expectedModel = new ModelManager(model.getExpenseBook(), new UserPrefs(), new AliasMap());
     }
 
     @Test

--- a/src/test/java/seedu/expense/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/RemarkCommandTest.java
@@ -1,27 +1,23 @@
 package seedu.expense.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.logic.commands.CommandTestUtil.VALID_REMARK_BUS;
-import static seedu.expense.logic.commands.CommandTestUtil.VALID_REMARK_FOOD;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
-
 import org.junit.jupiter.api.Test;
-
 import seedu.expense.commons.core.Messages;
 import seedu.expense.commons.core.index.Index;
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.Model;
 import seedu.expense.model.ModelManager;
 import seedu.expense.model.UserPrefs;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.model.expense.Remark;
 import seedu.expense.testutil.ExpenseBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.logic.commands.CommandTestUtil.*;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for RemarkCommand.
@@ -30,7 +26,7 @@ public class RemarkCommandTest {
 
     private static final String REMARK_STUB = "Some remark";
 
-    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalExpenseBook(), new UserPrefs(), new AliasMap());
 
     @Test
     public void execute_addRemarkUnfilteredList_success() {
@@ -42,7 +38,7 @@ public class RemarkCommandTest {
 
         String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
         expectedModel.setExpense(firstExpense, editedExpense);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
@@ -58,7 +54,7 @@ public class RemarkCommandTest {
 
         String expectedMessage = String.format(RemarkCommand.MESSAGE_DELETE_REMARK_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
         expectedModel.setExpense(firstExpense, editedExpense);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
@@ -78,7 +74,7 @@ public class RemarkCommandTest {
 
         String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
         expectedModel.setExpense(firstExpense, editedExpense);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/expense/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/RemarkCommandTest.java
@@ -1,6 +1,18 @@
 package seedu.expense.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_REMARK_BUS;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_REMARK_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.expense.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.expense.logic.commands.CommandTestUtil.showExpenseAtIndex;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
+import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.expense.commons.core.Messages;
 import seedu.expense.commons.core.index.Index;
 import seedu.expense.model.ExpenseBook;
@@ -11,13 +23,6 @@ import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.model.expense.Remark;
 import seedu.expense.testutil.ExpenseBuilder;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.logic.commands.CommandTestUtil.*;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_FIRST_EXPENSE;
-import static seedu.expense.testutil.TypicalIndexes.INDEX_SECOND_EXPENSE;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for RemarkCommand.
@@ -38,7 +43,8 @@ public class RemarkCommandTest {
 
         String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()),
+                new UserPrefs(), new AliasMap());
         expectedModel.setExpense(firstExpense, editedExpense);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
@@ -54,7 +60,8 @@ public class RemarkCommandTest {
 
         String expectedMessage = String.format(RemarkCommand.MESSAGE_DELETE_REMARK_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()),
+                new UserPrefs(), new AliasMap());
         expectedModel.setExpense(firstExpense, editedExpense);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
@@ -74,7 +81,8 @@ public class RemarkCommandTest {
 
         String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedExpense);
 
-        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()), new UserPrefs(), new AliasMap());
+        Model expectedModel = new ModelManager(new ExpenseBook(model.getExpenseBook()),
+                new UserPrefs(), new AliasMap());
         expectedModel.setExpense(firstExpense, editedExpense);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
@@ -1,23 +1,22 @@
 package seedu.expense.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.testutil.Assert.assertThrows;
-
-import java.nio.file.Path;
-import java.util.function.Predicate;
-
-import org.junit.jupiter.api.Test;
-
 import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.model.Model;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.ReadOnlyUserPrefs;
+import seedu.expense.model.alias.AliasEntry;
+import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.budget.Budget;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.expense.testutil.Assert.assertThrows;
 
 public class TopupCommandTest {
 
@@ -149,6 +148,36 @@ public class TopupCommandTest {
         @Override
         public void topupBudget(Amount amount) {
             budget.topupBudget(amount);
+        }
+
+        @Override
+        public void setAlias(AliasEntry prev, AliasEntry next) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAliasMap(AliasMap map) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public AliasMap getAliasMap() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addAlias(AliasEntry entry) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasAlias(AliasEntry entry) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteAlias(AliasEntry entry) {
+            throw new AssertionError("This method should not be called.");
         }
     }
 }

--- a/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
@@ -1,7 +1,16 @@
 package seedu.expense.logic.commands;
 
-import javafx.collections.ObservableList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.model.Model;
 import seedu.expense.model.ReadOnlyExpenseBook;
@@ -11,12 +20,6 @@ import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.budget.Budget;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
-
-import java.nio.file.Path;
-import java.util.function.Predicate;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.expense.testutil.Assert.assertThrows;
 
 public class TopupCommandTest {
 

--- a/src/test/java/seedu/expense/model/ModelManagerTest.java
+++ b/src/test/java/seedu/expense/model/ModelManagerTest.java
@@ -1,20 +1,23 @@
 package seedu.expense.model;
 
-import org.junit.jupiter.api.Test;
-import seedu.expense.commons.core.GuiSettings;
-import seedu.expense.model.alias.AliasMap;
-import seedu.expense.model.expense.NameContainsKeywordsPredicate;
-import seedu.expense.testutil.ExpenseBookBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.model.Model.PREDICATE_SHOW_ALL_EXPENSES;
+import static seedu.expense.testutil.Assert.assertThrows;
+import static seedu.expense.testutil.TypicalExpenses.FEL_BDAY;
+import static seedu.expense.testutil.TypicalExpenses.GRAB_HOME;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.expense.model.Model.PREDICATE_SHOW_ALL_EXPENSES;
-import static seedu.expense.testutil.Assert.assertThrows;
-import static seedu.expense.testutil.TypicalExpenses.FEL_BDAY;
-import static seedu.expense.testutil.TypicalExpenses.GRAB_HOME;
+import org.junit.jupiter.api.Test;
+
+import seedu.expense.commons.core.GuiSettings;
+import seedu.expense.model.alias.AliasMap;
+import seedu.expense.model.expense.NameContainsKeywordsPredicate;
+import seedu.expense.testutil.ExpenseBookBuilder;
 
 public class ModelManagerTest {
 

--- a/src/test/java/seedu/expense/model/ModelManagerTest.java
+++ b/src/test/java/seedu/expense/model/ModelManagerTest.java
@@ -1,22 +1,20 @@
 package seedu.expense.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.expense.model.Model.PREDICATE_SHOW_ALL_EXPENSES;
-import static seedu.expense.testutil.Assert.assertThrows;
-import static seedu.expense.testutil.TypicalExpenses.FEL_BDAY;
-import static seedu.expense.testutil.TypicalExpenses.GRAB_HOME;
+import org.junit.jupiter.api.Test;
+import seedu.expense.commons.core.GuiSettings;
+import seedu.expense.model.alias.AliasMap;
+import seedu.expense.model.expense.NameContainsKeywordsPredicate;
+import seedu.expense.testutil.ExpenseBookBuilder;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import org.junit.jupiter.api.Test;
-
-import seedu.expense.commons.core.GuiSettings;
-import seedu.expense.model.expense.NameContainsKeywordsPredicate;
-import seedu.expense.testutil.ExpenseBookBuilder;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.expense.model.Model.PREDICATE_SHOW_ALL_EXPENSES;
+import static seedu.expense.testutil.Assert.assertThrows;
+import static seedu.expense.testutil.TypicalExpenses.FEL_BDAY;
+import static seedu.expense.testutil.TypicalExpenses.GRAB_HOME;
 
 public class ModelManagerTest {
 
@@ -98,10 +96,11 @@ public class ModelManagerTest {
         ExpenseBook expenseBook = new ExpenseBookBuilder().withExpense(FEL_BDAY).withExpense(GRAB_HOME).build();
         ExpenseBook differentExpenseBook = new ExpenseBook();
         UserPrefs userPrefs = new UserPrefs();
+        AliasMap aliasMap = new AliasMap();
 
         // same values -> returns true
-        modelManager = new ModelManager(expenseBook, userPrefs);
-        ModelManager modelManagerCopy = new ModelManager(expenseBook, userPrefs);
+        modelManager = new ModelManager(expenseBook, userPrefs, aliasMap);
+        ModelManager modelManagerCopy = new ModelManager(expenseBook, userPrefs, aliasMap);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -114,12 +113,12 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different expenseBook -> returns false
-        assertFalse(modelManager.equals(new ModelManager(differentExpenseBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(differentExpenseBook, userPrefs, aliasMap)));
 
         // different filteredList -> returns false
         String[] keywords = FEL_BDAY.getDescription().fullDescription.split("\\s+");
         modelManager.updateFilteredExpenseList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new ModelManager(expenseBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(expenseBook, userPrefs, aliasMap)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredExpenseList(PREDICATE_SHOW_ALL_EXPENSES);
@@ -127,6 +126,6 @@ public class ModelManagerTest {
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setExpenseBookFilePath(Paths.get("differentFilePath"));
-        assertFalse(modelManager.equals(new ModelManager(expenseBook, differentUserPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(expenseBook, differentUserPrefs, aliasMap)));
     }
 }

--- a/src/test/java/seedu/expense/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/expense/storage/StorageManagerTest.java
@@ -1,19 +1,18 @@
 package seedu.expense.storage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
-
-import java.nio.file.Path;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.UserPrefs;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 
 public class StorageManagerTest {
 
@@ -26,7 +25,8 @@ public class StorageManagerTest {
     public void setUp() {
         JsonExpenseBookStorage expenseBookStorage = new JsonExpenseBookStorage(getTempFilePath("ab"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
-        storageManager = new StorageManager(expenseBookStorage, userPrefsStorage);
+        JsonAliasMapStorage aliasMapStorage = new JsonAliasMapStorage(getTempFilePath("als"));
+        storageManager = new StorageManager(expenseBookStorage, userPrefsStorage, aliasMapStorage);
     }
 
     private Path getTempFilePath(String fileName) {

--- a/src/test/java/seedu/expense/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/expense/storage/StorageManagerTest.java
@@ -1,18 +1,19 @@
 package seedu.expense.storage;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
+
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
 import seedu.expense.commons.core.GuiSettings;
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.ReadOnlyExpenseBook;
 import seedu.expense.model.UserPrefs;
-
-import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.expense.testutil.TypicalExpenses.getTypicalExpenseBook;
 
 public class StorageManagerTest {
 

--- a/src/test/resources/view/UiPartTest/validFileWithFxRoot.fxml
+++ b/src/test/resources/view/UiPartTest/validFileWithFxRoot.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import seedu.expense.ui.TestFxmlObject?>
 <fx:root type="seedu.expense.ui.TestFxmlObject" xmlns="http://javafx.com/javafx"
          xmlns:fx="http://javafx.com/fxml">
     <text>Hello World!</text>


### PR DESCRIPTION
Some key changes to take note of:
- ExpenseBookParser's parseCommand() accepts an AliasMap to parse alias commands into actual default commands
- StorageManager handles JsonAliasMapStorage
- Model has an AliasMap as well, allowing AliasCommand to execute and update the model's AliasMap (similar to ExpenseBook)
- AliasMap can be stored as JSON (refer to JsonSerializableAliasMap and JsonAdaptedAliasEntry for the format), and default userPrefs filePath for AliasMap storage is ./data/aliasmap.json

Test cases are not fully updated yet, as ExpenseBookParser's parseCommand() currently has an overloaded constructor.