### PR TITLE
Change tags behaviour

### DIFF
--- a/src/main/java/seedu/expense/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AddCommand.java
@@ -27,11 +27,12 @@ public class AddCommand extends Command {
             + PREFIX_DESCRIPTION + "Uniqlo Jacket "
             + PREFIX_AMOUNT + "59.90 "
             + PREFIX_DATE + "04-10-2020 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "friends ";
 
     public static final String MESSAGE_SUCCESS = "New expense added: %1$s";
     public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book";
+    public static final String MESSAGE_DEFAULT = "The category '%s' does not exist yet"
+            + " -- tagging as 'Default' instead";
 
     private final Expense toAdd;
 
@@ -49,6 +50,12 @@ public class AddCommand extends Command {
 
         if (model.hasExpense(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_EXPENSE);
+        }
+
+        if (!model.hasCategory(toAdd.getTag())) {
+            Expense expense = toAdd.resetTag();
+            model.addExpense(expense);
+            return new CommandResult(String.format(MESSAGE_DEFAULT, expense));
         }
 
         model.addExpense(toAdd);

--- a/src/main/java/seedu/expense/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/EditCommand.java
@@ -7,11 +7,8 @@ import static seedu.expense.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.expense.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.expense.model.Model.PREDICATE_SHOW_ALL_EXPENSES;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import seedu.expense.commons.core.Messages;
 import seedu.expense.commons.core.index.Index;
@@ -95,9 +92,9 @@ public class EditCommand extends Command {
         Amount updatedAmount = editExpenseDescriptor.getAmount().orElse(expenseToEdit.getAmount());
         Date updatedDate = editExpenseDescriptor.getDate().orElse(expenseToEdit.getDate());
         Remark updatedRemark = expenseToEdit.getRemark(); // edit command does not allow editing remarks
-        Set<Tag> updatedTags = editExpenseDescriptor.getTags().orElse(expenseToEdit.getTags());
+        Tag updatedTag = editExpenseDescriptor.getTag().orElse(expenseToEdit.getTag());
 
-        return new Expense(updatedDescription, updatedAmount, updatedDate, updatedRemark, updatedTags);
+        return new Expense(updatedDescription, updatedAmount, updatedDate, updatedRemark, updatedTag);
     }
 
     @Override
@@ -127,7 +124,7 @@ public class EditCommand extends Command {
         private Description description;
         private Amount amount;
         private Date date;
-        private Set<Tag> tags;
+        private Tag tag;
 
         public EditExpenseDescriptor() {
         }
@@ -140,14 +137,14 @@ public class EditCommand extends Command {
             setDescription(toCopy.description);
             setAmount(toCopy.amount);
             setDate(toCopy.date);
-            setTags(toCopy.tags);
+            setTag(toCopy.tag);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(description, amount, date, tags);
+            return CollectionUtil.isAnyNonNull(description, amount, date, tag);
         }
 
         public void setDescription(Description description) {
@@ -174,21 +171,17 @@ public class EditCommand extends Command {
             return Optional.ofNullable(date);
         }
 
-        /**
-         * Sets {@code tags} to this object's {@code tags}.
-         * A defensive copy of {@code tags} is used internally.
-         */
-        public void setTags(Set<Tag> tags) {
-            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        public void setTag(Tag tag) {
+            this.tag = tag;
         }
 
         /**
          * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
          * if modification is attempted.
-         * Returns {@code Optional#empty()} if {@code tags} is null.
+         * Returns {@code Optional#empty()} if {@code tag} is null.
          */
-        public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        public Optional<Tag> getTag() {
+            return Optional.ofNullable(tag);
         }
 
         @Override
@@ -209,7 +202,7 @@ public class EditCommand extends Command {
             return getDescription().equals(e.getDescription())
                     && getAmount().equals(e.getAmount())
                     && getDate().equals(e.getDate())
-                    && getTags().equals(e.getTags());
+                    && getTag().equals(e.getTag());
         }
     }
 }

--- a/src/main/java/seedu/expense/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/RemarkCommand.java
@@ -56,7 +56,7 @@ public class RemarkCommand extends Command {
         Expense expenseToEdit = lastShownList.get(index.getZeroBased());
         Expense editedExpense = new Expense(expenseToEdit.getDescription(),
                 expenseToEdit.getAmount(), expenseToEdit.getDate(),
-                remark, expenseToEdit.getTags());
+                remark, expenseToEdit.getTag());
 
         model.setExpense(expenseToEdit, editedExpense);
         model.updateFilteredExpenseList(PREDICATE_SHOW_ALL_EXPENSES);

--- a/src/main/java/seedu/expense/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/expense/logic/parser/AddCommandParser.java
@@ -5,8 +5,8 @@ import static seedu.expense.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.expense.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.expense.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.expense.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.expense.model.ExpenseBook.DEFAULT_TAG;
 
-import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.expense.logic.commands.AddCommand;
@@ -43,14 +43,21 @@ public class AddCommandParser implements Parser<AddCommand> {
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Remark remark = new Remark(""); // add command does not allow adding remarks straight away
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        Tag tag;
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            tag = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get());
+        } else {
+            tag = DEFAULT_TAG;
+        }
+
         Date date;
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
             date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         } else {
             date = new Date(); // creates a default Date object with date set as now.
         }
-        Expense expense = new Expense(description, amount, date, remark, tagList);
+        Expense expense = new Expense(description, amount, date, remark, tag);
 
         return new AddCommand(expense);
     }

--- a/src/main/java/seedu/expense/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/expense/logic/parser/EditCommandParser.java
@@ -53,7 +53,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
             editExpenseDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editExpenseDescriptor::setTags);
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            editExpenseDescriptor.setTag(ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get()));
+        }
 
         if (!editExpenseDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -66,6 +68,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
      * If {@code tags} contain only one element which is an empty string, it will be parsed into a
      * {@code Set<Tag>} containing zero tags.
+     * @Deprecated since v1.3.
      */
     private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
         assert tags != null;

--- a/src/main/java/seedu/expense/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/expense/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.expense.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.expense.model.ExpenseBook.DEFAULT_TAG;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -89,6 +90,10 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
+        if (trimmedTag.isEmpty()) { // reset the tag to the default tag
+            return DEFAULT_TAG;
+        }
+
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/expense/model/ModelManager.java
+++ b/src/main/java/seedu/expense/model/ModelManager.java
@@ -204,7 +204,7 @@ public class ModelManager implements Model {
             updateFilteredExpenseList(PREDICATE_SHOW_ALL_EXPENSES);
         } else {
             updateFilteredBudgetList(budget -> budget.getTag().equals(category));
-            updateFilteredExpenseList(expense -> expense.getTags().contains(category));
+            updateFilteredExpenseList(expense -> expense.getTag().equals(category));
         }
     }
 

--- a/src/main/java/seedu/expense/model/expense/Expense.java
+++ b/src/main/java/seedu/expense/model/expense/Expense.java
@@ -2,10 +2,7 @@ package seedu.expense.model.expense;
 
 import static seedu.expense.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 
 import seedu.expense.model.tag.Tag;
 
@@ -22,18 +19,18 @@ public class Expense {
 
     // Data fields
     private final Remark remark;
-    private final Set<Tag> tags = new HashSet<>();
+    private final Tag tag;
 
     /**
      * Every field must be present and not null.
      */
-    public Expense(Description description, Amount amount, Date date, Remark remark, Set<Tag> tags) {
-        requireAllNonNull(description, amount, date, tags);
+    public Expense(Description description, Amount amount, Date date, Remark remark, Tag tag) {
+        requireAllNonNull(description, amount, date, tag);
         this.description = description;
         this.amount = amount;
         this.date = date;
         this.remark = remark;
-        this.tags.addAll(tags);
+        this.tag = tag;
     }
 
     public Description getDescription() {
@@ -52,12 +49,8 @@ public class Expense {
         return remark;
     }
 
-    /**
-     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
-     * if modification is attempted.
-     */
-    public Set<Tag> getTags() {
-        return Collections.unmodifiableSet(tags);
+    public Tag getTag() {
+        return tag;
     }
 
     /**
@@ -92,13 +85,13 @@ public class Expense {
         return otherExpense.getDescription().equals(getDescription())
                 && otherExpense.getAmount().equals(getAmount())
                 && otherExpense.getDate().equals(getDate())
-                && otherExpense.getTags().equals(getTags());
+                && otherExpense.getTag().equals(getTag());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(description, amount, date, tags);
+        return Objects.hash(description, amount, date, tag);
     }
 
     @Override
@@ -111,8 +104,8 @@ public class Expense {
                 .append(getDate())
                 .append(" Remark: ")
                 .append(getRemark())
-                .append(" Tags: ");
-        getTags().forEach(builder::append);
+                .append(" Tags: ")
+                .append(getTag());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/expense/model/expense/Expense.java
+++ b/src/main/java/seedu/expense/model/expense/Expense.java
@@ -1,6 +1,7 @@
 package seedu.expense.model.expense;
 
 import static seedu.expense.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.expense.model.ExpenseBook.DEFAULT_TAG;
 
 import java.util.Objects;
 
@@ -53,6 +54,10 @@ public class Expense {
         return tag;
     }
 
+    public Expense resetTag() {
+        return new Expense(description, amount, date, remark, DEFAULT_TAG);
+    }
+
     /**
      * Returns true if both expenses of the same description have at least one other identity field that is the same.
      * This defines a weaker notion of equality between two expenses.
@@ -84,14 +89,13 @@ public class Expense {
         Expense otherExpense = (Expense) other;
         return otherExpense.getDescription().equals(getDescription())
                 && otherExpense.getAmount().equals(getAmount())
-                && otherExpense.getDate().equals(getDate())
-                && otherExpense.getTag().equals(getTag());
+                && otherExpense.getDate().equals(getDate());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(description, amount, date, tag);
+        return Objects.hash(description, amount, date);
     }
 
     @Override

--- a/src/main/java/seedu/expense/model/expense/TagsMatchesPredicate.java
+++ b/src/main/java/seedu/expense/model/expense/TagsMatchesPredicate.java
@@ -25,7 +25,7 @@ public class TagsMatchesPredicate implements Predicate<Expense> {
     @Override
     public boolean test(Expense expense) {
         for (Tag t: this.tags) {
-            if (expense.getTags().contains(t)) {
+            if (expense.getTag().equals(t)) {
                 return true;
             }
         }

--- a/src/main/java/seedu/expense/model/tag/Tag.java
+++ b/src/main/java/seedu/expense/model/tag/Tag.java
@@ -21,8 +21,12 @@ public class Tag {
      */
     public Tag(String tagName) {
         requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        if (!tagName.isBlank()) {
+            checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
+            this.tagName = tagName;
+        } else {
+            this.tagName = "Default";
+        }
     }
 
     /**
@@ -48,7 +52,7 @@ public class Tag {
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + tagName + ']';
+        return tagName;
     }
 
 }

--- a/src/main/java/seedu/expense/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/expense/model/util/SampleDataUtil.java
@@ -26,34 +26,25 @@ public class SampleDataUtil {
         return new Expense[]{
             new Expense(new Description("Felicia's Birthday"), new Amount("140.00"), new Date("02-07-2020"),
                 new Remark("Birthday surprise with friends + birthday presents + birthday dinner"),
-                getTagSet("Girlfriend", "Shopping", "Food")),
+                new Tag("Girlfriend")),
             new Expense(new Description("Lunch with Hostel Mates"), new Amount("13"), new Date("01-07-2020"),
-                EMPTY_REMARK,
-                getTagSet("Food")),
+                EMPTY_REMARK, new Tag("Food")),
             new Expense(new Description("Grab Home"), new Amount("15"), new Date("01-07-2020"),
-                new Remark("Need to stop grabbing so much!"),
-                getTagSet("Transport")),
+                new Remark("Need to stop grabbing so much!"), new Tag("Transport")),
             new Expense(new Description("ZARA Jacket"), new Amount("80"), new Date("30-06-2020"),
-                EMPTY_REMARK,
-                getTagSet("Shopping")),
+                EMPTY_REMARK, new Tag("Shopping")),
             new Expense(new Description("Ramen with Tyler"), new Amount("18.50"), new Date("29-06-2020"),
-                new Remark("Tori King @ Tanjong Pagar"),
-                getTagSet("Food")),
+                new Remark("Tori King @ Tanjong Pagar"), new Tag("Food")),
             new Expense(new Description("Phone Bill Payment"), new Amount("35.90"), new Date("29-06-2020"),
-                EMPTY_REMARK,
-                getTagSet("Bills")),
+                EMPTY_REMARK, new Tag("Bills")),
             new Expense(new Description("Grab to Supper"), new Amount("5"), new Date("28-06-2020"),
-                EMPTY_REMARK,
-                getTagSet("Food")),
+                EMPTY_REMARK, new Tag("Food")),
             new Expense(new Description("Movie with Felicia"), new Amount("14"), new Date("26-06-2020"),
-                new Remark("Tenet was so confusing..."),
-                getTagSet("Girlfriend")),
+                new Remark("Tenet was so confusing..."), new Tag("Girlfriend")),
             new Expense(new Description("Top-up Ez-Link"), new Amount("20"), new Date("25-06-2020"),
-                EMPTY_REMARK,
-                getTagSet("Transport")),
+                EMPTY_REMARK, new Tag("Transport")),
             new Expense(new Description("Caifan"), new Amount("3.80"), new Date("25-06-2020"),
-                EMPTY_REMARK,
-                getTagSet("Food"))
+                EMPTY_REMARK, new Tag("Food"))
         };
     }
 
@@ -75,6 +66,7 @@ public class SampleDataUtil {
 
     /**
      * Returns a tag set containing the list of strings given.
+     * @Deprecated since v1.3
      */
     public static Set<Tag> getTagSet(String... strings) {
         return Arrays.stream(strings)

--- a/src/main/java/seedu/expense/ui/ExpenseCard.java
+++ b/src/main/java/seedu/expense/ui/ExpenseCard.java
@@ -1,7 +1,5 @@
 package seedu.expense.ui;
 
-import java.util.Comparator;
-
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
@@ -52,9 +50,7 @@ public class ExpenseCard extends UiPart<Region> {
         amount.setText("$" + expense.getAmount().toString());
         date.setText(expense.getDate().toString());
         remark.setText(expense.getRemark().value);
-        expense.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        tags.getChildren().add(new Label(expense.getTag().tagName));
     }
 
     @Override

--- a/src/test/data/JsonSerializableAddressBookTest/typicalExpensesLedger.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalExpensesLedger.json
@@ -5,43 +5,43 @@
     "amount" : "140",
     "date" : "02-07-2020",
     "remark" : "Birthday surprise with friends + birthday presents + birthday dinner",
-    "tagged" : [ "Girlfriend", "Shopping", "Food" ]
+    "tagged" : "Girlfriend"
   }, {
     "description" : "Grab Home",
     "amount" : "15",
     "date" : "01-07-2020",
     "remark" : "Need to stop grabbing so much!",
-    "tagged" : [ "Transport" ]
+    "tagged" : "Transport"
   }, {
     "description" : "ZARA Jacket",
     "amount" : "80",
     "date" : "30-06-2020",
     "remark" : "",
-    "tagged" : [ "Shopping" ]
+    "tagged" : "Shopping"
   }, {
     "description" : "Ramen with Tyler",
     "amount" : "18.50",
     "date" : "29-06-2020",
     "remark" : "",
-    "tagged" : [ "Food" ]
+    "tagged" : "Food"
   }, {
     "description" : "Phone Bill Payment",
     "amount" : "35.90",
     "date" : "29-06-2020",
     "remark" : "",
-    "tagged" : [ ]
+    "tagged" : "Default"
   }, {
     "description" : "Grab to Supper",
     "amount" : "5",
     "date" : "28-06-2020",
     "remark" : "",
-    "tagged" : [ ]
+    "tagged" : "Default"
   }, {
     "description" : "Swee Choon Supper",
     "amount" : "12.40",
     "date" : "28-06-2020",
     "remark" : "",
-    "tagged" : [ ]
+    "tagged" : "Default"
   } ],
   "budget": {
     "defaultCategory": {
@@ -49,10 +49,6 @@
       "amount": "10.00"
     },
     "categoryBudgets": [
-      {
-        "tag": "Food",
-        "amount": "100.00"
-      },
       {
         "tag": "Transport",
         "amount": "50.00"

--- a/src/test/data/JsonSerializableExpenseBookTest/duplicateExpenseLedger.json
+++ b/src/test/data/JsonSerializableExpenseBookTest/duplicateExpenseLedger.json
@@ -4,12 +4,13 @@
     "amount": "3.00",
     "date": "04-10-2020",
     "remark" : "",
-    "tagged": [ "friends" ]
+    "tagged": "friends"
   }, {
     "description": "Lunch Bak Chor Mee",
     "amount": "3.00",
     "date": "05-10-2020",
-    "remark" : ""
+    "remark" : "",
+    "tagged": "Default"
   } ],
   "budget": {
     "defaultCategory": {

--- a/src/test/data/JsonSerializableExpenseBookTest/typicalExpensesLedger.json
+++ b/src/test/data/JsonSerializableExpenseBookTest/typicalExpensesLedger.json
@@ -5,43 +5,43 @@
     "amount" : "140",
     "date" : "02-07-2020",
     "remark" : "Birthday surprise with friends + birthday presents + birthday dinner",
-    "tagged" : [ "Girlfriend", "Shopping", "Food" ]
+    "tagged" : "Girlfriend"
   }, {
     "description" : "Grab Home",
     "amount" : "15",
     "date" : "01-07-2020",
     "remark" : "Need to stop grabbing so much!",
-    "tagged" : [ "Transport" ]
+    "tagged" : "Transport"
   }, {
     "description" : "ZARA Jacket",
     "amount" : "80",
     "date" : "30-06-2020",
     "remark" : "",
-    "tagged" : [ "Shopping" ]
+    "tagged" : "Shopping"
   }, {
     "description" : "Ramen with Tyler",
     "amount" : "18.50",
     "date" : "29-06-2020",
     "remark" : "",
-    "tagged" : [ "Food" ]
+    "tagged" : "Food"
   }, {
     "description" : "Phone Bill Payment",
     "amount" : "35.90",
     "date" : "29-06-2020",
     "remark" : "",
-    "tagged" : [ ]
+    "tagged" : "Default"
   }, {
     "description" : "Grab to Supper",
     "amount" : "5",
     "date" : "28-06-2020",
     "remark" : "",
-    "tagged" : [ ]
+    "tagged" : "Default"
   }, {
     "description" : "Swee Choon Supper",
     "amount" : "12.40",
     "date" : "28-06-2020",
     "remark" : "",
-    "tagged" : [ ]
+    "tagged" : "Default"
   } ],
   "budget": {
     "defaultCategory": {

--- a/src/test/java/seedu/expense/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/expense/logic/LogicManagerTest.java
@@ -6,6 +6,7 @@ import static seedu.expense.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.expense.logic.commands.CommandTestUtil.AMOUNT_DESC_FOOD;
 import static seedu.expense.logic.commands.CommandTestUtil.DATE_DESC_FOOD;
 import static seedu.expense.logic.commands.CommandTestUtil.DESCRIPTION_DESC_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.TAG_DESC_FOOD;
 import static seedu.expense.testutil.Assert.assertThrows;
 import static seedu.expense.testutil.TypicalExpenses.FOOD;
 
@@ -83,8 +84,9 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Execute add command
-        String addCommand = AddCommand.COMMAND_WORD + DESCRIPTION_DESC_FOOD + AMOUNT_DESC_FOOD + DATE_DESC_FOOD;
-        Expense expectedExpense = new ExpenseBuilder(FOOD).withTags().build();
+        String addCommand = AddCommand.COMMAND_WORD + DESCRIPTION_DESC_FOOD + AMOUNT_DESC_FOOD
+                + DATE_DESC_FOOD + TAG_DESC_FOOD;
+        Expense expectedExpense = new ExpenseBuilder(FOOD).build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addExpense(expectedExpense);
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;

--- a/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.expense.model.ExpenseBook.DEFAULT_TAG;
 import static seedu.expense.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -248,6 +249,7 @@ public class AddCommandTest {
      */
     private class ModelStubAcceptingExpenseAdded extends ModelStub {
         final ArrayList<Expense> expensesAdded = new ArrayList<>();
+        final Tag tag = DEFAULT_TAG;
 
         @Override
         public boolean hasExpense(Expense expense) {
@@ -259,6 +261,11 @@ public class AddCommandTest {
         public void addExpense(Expense expense) {
             requireNonNull(expense);
             expensesAdded.add(expense);
+        }
+
+        @Override
+        public boolean hasCategory(Tag toCheck) {
+            return toCheck.equals(tag);
         }
 
         @Override

--- a/src/test/java/seedu/expense/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/expense/logic/commands/CommandTestUtil.java
@@ -27,10 +27,13 @@ public class CommandTestUtil {
 
     public static final String VALID_DESCRIPTION_FOOD = "Caifan lunch";
     public static final String VALID_DESCRIPTION_BUS = "Coach ride to Malacca";
+    public static final String VALID_DESCRIPTION_MISC = "Miscellaneous";
     public static final String VALID_AMOUNT_FOOD = "3.80";
     public static final String VALID_AMOUNT_BUS = "63";
+    public static final String VALID_AMOUNT_MISC = "4.20";
     public static final String VALID_DATE_FOOD = "04-10-2020";
     public static final String VALID_DATE_BUS = "09-11-2020";
+    public static final String VALID_DATE_MISC = "15-12-2020";
     public static final String VALID_REMARK_FOOD = "The usual: Steamed egg, ladies finger, sweet n sour pork.";
     public static final String VALID_REMARK_BUS = "We're going on a trip??";
     public static final String VALID_TAG_FOOD = "Food";
@@ -38,8 +41,10 @@ public class CommandTestUtil {
 
     public static final String DESCRIPTION_DESC_FOOD = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_FOOD;
     public static final String DESCRIPTION_DESC_BUS = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_BUS;
+    public static final String DESCRIPTION_DESC_MISC = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION_MISC;
     public static final String AMOUNT_DESC_FOOD = " " + PREFIX_AMOUNT + VALID_AMOUNT_FOOD;
     public static final String AMOUNT_DESC_BUS = " " + PREFIX_AMOUNT + VALID_AMOUNT_BUS;
+    public static final String AMOUNT_DESC_MISC = " " + PREFIX_AMOUNT + VALID_AMOUNT_MISC;
     public static final String DATE_DESC_FOOD = " " + PREFIX_DATE + VALID_DATE_FOOD;
     public static final String DATE_DESC_BUS = " " + PREFIX_DATE + VALID_DATE_BUS;
     public static final String TAG_DESC_FOOD = " " + PREFIX_TAG + VALID_TAG_FOOD;
@@ -59,10 +64,10 @@ public class CommandTestUtil {
     static {
         DESC_FOOD = new EditExpenseDescriptorBuilder().withDescription(VALID_DESCRIPTION_FOOD)
                 .withAmount(VALID_AMOUNT_FOOD).withDate(VALID_DATE_FOOD)
-                .withTags(VALID_TAG_FOOD).build();
+                .withTag(VALID_TAG_FOOD).build();
         DESC_BUS = new EditExpenseDescriptorBuilder().withDescription(VALID_DESCRIPTION_BUS)
                 .withAmount(VALID_AMOUNT_BUS).withDate(VALID_DATE_BUS)
-                .withTags(VALID_TAG_TRANSPORT, VALID_TAG_FOOD).build();
+                .withTag(VALID_TAG_TRANSPORT).build();
     }
 
     /**

--- a/src/test/java/seedu/expense/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/EditCommandTest.java
@@ -59,11 +59,11 @@ public class EditCommandTest {
 
         ExpenseBuilder expenseInList = new ExpenseBuilder(lastExpense);
         Expense editedExpense = expenseInList.withDescription(VALID_DESCRIPTION_BUS).withAmount(VALID_AMOUNT_BUS)
-                .withTags(VALID_TAG_TRANSPORT).build();
+                .withTag(VALID_TAG_TRANSPORT).build();
 
         EditCommand.EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder()
                 .withDescription(VALID_DESCRIPTION_BUS)
-                .withAmount(VALID_AMOUNT_BUS).withTags(VALID_TAG_TRANSPORT).build();
+                .withAmount(VALID_AMOUNT_BUS).withTag(VALID_TAG_TRANSPORT).build();
         EditCommand editCommand = new EditCommand(indexLastExpense, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense);

--- a/src/test/java/seedu/expense/logic/commands/EditExpenseDescriptorTest.java
+++ b/src/test/java/seedu/expense/logic/commands/EditExpenseDescriptorTest.java
@@ -47,7 +47,7 @@ public class EditExpenseDescriptorTest {
         assertFalse(DESC_FOOD.equals(editedFood));
 
         // different tags -> returns false
-        editedFood = new EditExpenseDescriptorBuilder(DESC_FOOD).withTags(VALID_TAG_TRANSPORT).build();
+        editedFood = new EditExpenseDescriptorBuilder(DESC_FOOD).withTag(VALID_TAG_TRANSPORT).build();
         assertFalse(DESC_FOOD.equals(editedFood));
     }
 }

--- a/src/test/java/seedu/expense/logic/commands/SwitchCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/SwitchCommandTest.java
@@ -39,7 +39,7 @@ class SwitchCommandTest {
     }
 
     @Test
-    void execute_noMatchingKeywords_noCategoryFound() throws Exception {
+    void execute_noMatchingKeywords_noCategoryFound() {
         Tag foodTag = new Tag(VALID_TAG_FOOD);
         SwitchCommand command = new SwitchCommand(foodTag);
         ModelStub modelStub = new ModelStub();
@@ -174,7 +174,7 @@ class SwitchCommandTest {
                 updateFilteredExpenseList(expense -> true);
             } else {
                 updateFilteredBudgetList(budget -> budget.getTag().equals(category));
-                updateFilteredExpenseList(expense -> expense.getTags().contains(category));
+                updateFilteredExpenseList(expense -> expense.getTag().equals(category));
             }
         }
 

--- a/src/test/java/seedu/expense/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/expense/logic/parser/AddCommandParserTest.java
@@ -3,10 +3,12 @@ package seedu.expense.logic.parser;
 import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.expense.logic.commands.CommandTestUtil.AMOUNT_DESC_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.AMOUNT_DESC_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.AMOUNT_DESC_MISC;
 import static seedu.expense.logic.commands.CommandTestUtil.DATE_DESC_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.DATE_DESC_FOOD;
 import static seedu.expense.logic.commands.CommandTestUtil.DESCRIPTION_DESC_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.DESCRIPTION_DESC_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.DESCRIPTION_DESC_MISC;
 import static seedu.expense.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
 import static seedu.expense.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.expense.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
@@ -22,7 +24,7 @@ import static seedu.expense.logic.commands.CommandTestUtil.VALID_TAG_TRANSPORT;
 import static seedu.expense.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.expense.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.expense.testutil.TypicalExpenses.BUS;
-import static seedu.expense.testutil.TypicalExpenses.FOOD;
+import static seedu.expense.testutil.TypicalExpenses.MISC;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -42,7 +44,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Expense expectedExpense = new ExpenseBuilder(BUS).withTags(VALID_TAG_TRANSPORT).build();
+        Expense expectedExpense = new ExpenseBuilder(BUS).withTag(VALID_TAG_TRANSPORT).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + DESCRIPTION_DESC_BUS + AMOUNT_DESC_BUS + DATE_DESC_BUS
@@ -60,19 +62,17 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, DESCRIPTION_DESC_BUS + AMOUNT_DESC_BUS + DATE_DESC_FOOD + DATE_DESC_BUS
                 + TAG_DESC_TRANSPORT, new AddCommand(expectedExpense));
 
-        // multiple tags - all accepted
-        Expense expectedExpenseMultipleTags = new ExpenseBuilder(BUS).withTags(VALID_TAG_FOOD, VALID_TAG_TRANSPORT)
-                .build();
+        // multiple tags - last tag accepted
         assertParseSuccess(parser, DESCRIPTION_DESC_BUS + AMOUNT_DESC_BUS + DATE_DESC_BUS
-                + TAG_DESC_FOOD + TAG_DESC_TRANSPORT, new AddCommand(expectedExpenseMultipleTags));
+                + TAG_DESC_FOOD + TAG_DESC_TRANSPORT, new AddCommand(expectedExpense));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        Expense expectedExpense = new ExpenseBuilder(FOOD).withTags().withDate(LocalDate.now()
+        Expense expectedExpense = new ExpenseBuilder(MISC).withDate(LocalDate.now()
                 .format(DateTimeFormatter.ofPattern("dd-MM-yyyy"))).build(); // date set to today.
-        assertParseSuccess(parser, DESCRIPTION_DESC_FOOD + AMOUNT_DESC_FOOD,
+        assertParseSuccess(parser, DESCRIPTION_DESC_MISC + AMOUNT_DESC_MISC,
                 new AddCommand(expectedExpense));
     }
 
@@ -112,7 +112,7 @@ public class AddCommandParserTest {
                 + INVALID_TAG_DESC + VALID_TAG_FOOD, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_DESCRIPTION_DESC + AMOUNT_DESC_BUS,
+        assertParseFailure(parser, INVALID_DESCRIPTION_DESC + AMOUNT_DESC_BUS + INVALID_TAG_DESC,
                 Description.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble

--- a/src/test/java/seedu/expense/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/expense/logic/parser/EditCommandParserTest.java
@@ -87,12 +87,6 @@ public class EditCommandParserTest {
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + AMOUNT_DESC_BUS + INVALID_AMOUNT_DESC, Amount.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Expense} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_TRANSPORT + TAG_DESC_FOOD + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_TRANSPORT + TAG_EMPTY + TAG_DESC_FOOD, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_TRANSPORT + TAG_DESC_FOOD, Tag.MESSAGE_CONSTRAINTS);
-
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,
                 "1" + INVALID_DESCRIPTION_DESC + INVALID_DATE_DESC + VALID_AMOUNT_FOOD,
@@ -107,7 +101,7 @@ public class EditCommandParserTest {
 
         EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder().withDescription(VALID_DESCRIPTION_FOOD)
                 .withAmount(VALID_AMOUNT_BUS).withDate(VALID_DATE_FOOD)
-                .withTags(VALID_TAG_TRANSPORT, VALID_TAG_FOOD).build();
+                .withTag(VALID_TAG_TRANSPORT).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -148,7 +142,7 @@ public class EditCommandParserTest {
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_TRANSPORT;
-        descriptor = new EditExpenseDescriptorBuilder().withTags(VALID_TAG_TRANSPORT).build();
+        descriptor = new EditExpenseDescriptorBuilder().withTag(VALID_TAG_TRANSPORT).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -161,7 +155,7 @@ public class EditCommandParserTest {
                 + AMOUNT_DESC_BUS + DATE_DESC_BUS + TAG_DESC_FOOD;
 
         EditCommand.EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder().withAmount(VALID_AMOUNT_BUS)
-                .withDate(VALID_DATE_BUS).withTags(VALID_TAG_FOOD, VALID_TAG_TRANSPORT)
+                .withDate(VALID_DATE_BUS).withTag(VALID_TAG_FOOD)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -187,11 +181,11 @@ public class EditCommandParserTest {
     }
 
     @Test
-    public void parse_resetTags_success() {
+    public void parse_resetTags_success() throws Exception {
         Index targetIndex = INDEX_THIRD_EXPENSE;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
-        EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder().withTags().build();
+        EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder().withTag("").build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/expense/model/CategoryExpenseBookTest.java
+++ b/src/test/java/seedu/expense/model/CategoryExpenseBookTest.java
@@ -48,7 +48,7 @@ class CategoryExpenseBookTest {
     @Test
     public void resetData_withDuplicateExpenses_throwsDuplicateExpenseException() {
         // Two expenses with the same identity fields
-        Expense edited = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT)
+        Expense edited = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT)
             .build();
         List<Expense> newExpenses = Arrays.asList(FEL_BDAY, edited);
         CategoryExpenseBookTest.CategoryExpenseBookStub newData =
@@ -76,7 +76,7 @@ class CategoryExpenseBookTest {
     @Test
     public void hasExpense_expenseWithSameIdentityFieldsInCategoryExpenseBook_returnsTrue() {
         categoryExpenseBook.addExpense(FEL_BDAY);
-        Expense edited = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT)
+        Expense edited = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT)
             .build();
         assertTrue(categoryExpenseBook.hasExpense(edited));
     }

--- a/src/test/java/seedu/expense/model/ExpenseBookTest.java
+++ b/src/test/java/seedu/expense/model/ExpenseBookTest.java
@@ -47,7 +47,7 @@ public class ExpenseBookTest {
     @Test
     public void resetData_withDuplicateExpenses_throwsDuplicateExpenseException() {
         // Two expenses with the same identity fields
-        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT)
+        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT)
                 .build();
         List<Expense> newExpenses = Arrays.asList(FEL_BDAY, editedAlice);
         ExpenseBookStub newData = new ExpenseBookStub(newExpenses);
@@ -74,7 +74,7 @@ public class ExpenseBookTest {
     @Test
     public void hasExpense_expenseWithSameIdentityFieldsInExpenseBook_returnsTrue() {
         expenseBook.addExpense(FEL_BDAY);
-        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT)
+        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT)
                 .build();
         assertTrue(expenseBook.hasExpense(editedAlice));
     }

--- a/src/test/java/seedu/expense/model/expense/ExpenseTest.java
+++ b/src/test/java/seedu/expense/model/expense/ExpenseTest.java
@@ -77,9 +77,5 @@ public class ExpenseTest {
         // different date -> returns false
         editedAlice = new ExpenseBuilder(FEL_BDAY).withDate(VALID_DATE_BUS).build();
         assertFalse(FEL_BDAY.equals(editedAlice));
-
-        // different tags -> returns false
-        editedAlice = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT).build();
-        assertFalse(FEL_BDAY.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/expense/model/expense/ExpenseTest.java
+++ b/src/test/java/seedu/expense/model/expense/ExpenseTest.java
@@ -6,7 +6,6 @@ import static seedu.expense.logic.commands.CommandTestUtil.VALID_AMOUNT_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_DATE_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_TAG_TRANSPORT;
-import static seedu.expense.testutil.Assert.assertThrows;
 import static seedu.expense.testutil.TypicalExpenses.BUS;
 import static seedu.expense.testutil.TypicalExpenses.FEL_BDAY;
 
@@ -15,12 +14,6 @@ import org.junit.jupiter.api.Test;
 import seedu.expense.testutil.ExpenseBuilder;
 
 public class ExpenseTest {
-
-    @Test
-    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
-        Expense expense = new ExpenseBuilder().build();
-        assertThrows(UnsupportedOperationException.class, () -> expense.getTags().remove(0));
-    }
 
     @Test
     public void isSameExpense() {
@@ -42,16 +35,16 @@ public class ExpenseTest {
 
         // same description, same amount, different attributes -> returns true
         editedFelBD = new ExpenseBuilder(FEL_BDAY).withDate(VALID_DATE_BUS)
-                .withTags(VALID_TAG_TRANSPORT).build();
+                .withTag(VALID_TAG_TRANSPORT).build();
         assertTrue(FEL_BDAY.isSameExpense(editedFelBD));
 
         // same description, same date, different attributes -> returns true
         editedFelBD = new ExpenseBuilder(FEL_BDAY).withAmount(VALID_AMOUNT_BUS)
-                .withTags(VALID_TAG_TRANSPORT).build();
+                .withTag(VALID_TAG_TRANSPORT).build();
         assertTrue(FEL_BDAY.isSameExpense(editedFelBD));
 
         // same description, same amount, same date, different attributes -> returns true
-        editedFelBD = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT).build();
+        editedFelBD = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT).build();
         assertTrue(FEL_BDAY.isSameExpense(editedFelBD));
     }
 
@@ -86,7 +79,7 @@ public class ExpenseTest {
         assertFalse(FEL_BDAY.equals(editedAlice));
 
         // different tags -> returns false
-        editedAlice = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT).build();
+        editedAlice = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT).build();
         assertFalse(FEL_BDAY.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/expense/model/expense/UniqueExpenseListTest.java
+++ b/src/test/java/seedu/expense/model/expense/UniqueExpenseListTest.java
@@ -41,7 +41,7 @@ public class UniqueExpenseListTest {
     @Test
     public void contains_expenseWithSameIdentityFieldsInList_returnsTrue() {
         uniqueExpenseList.add(FEL_BDAY);
-        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT)
+        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT)
                 .build();
         assertTrue(uniqueExpenseList.contains(editedAlice));
     }
@@ -84,7 +84,7 @@ public class UniqueExpenseListTest {
     @Test
     public void setExpense_editedExpenseHasSameIdentity_success() {
         uniqueExpenseList.add(FEL_BDAY);
-        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTags(VALID_TAG_TRANSPORT)
+        Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT)
                 .build();
         uniqueExpenseList.setExpense(FEL_BDAY, editedAlice);
         UniqueExpenseList expectedUniqueExpenseList = new UniqueExpenseList();

--- a/src/test/java/seedu/expense/model/tag/TagTest.java
+++ b/src/test/java/seedu/expense/model/tag/TagTest.java
@@ -13,7 +13,7 @@ public class TagTest {
 
     @Test
     public void constructor_invalidTagName_throwsIllegalArgumentException() {
-        String invalidTagName = "";
+        String invalidTagName = "friend*";
         assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
     }
 

--- a/src/test/java/seedu/expense/storage/JsonAdaptedExpenseTest.java
+++ b/src/test/java/seedu/expense/storage/JsonAdaptedExpenseTest.java
@@ -5,10 +5,6 @@ import static seedu.expense.storage.JsonAdaptedExpense.MISSING_FIELD_MESSAGE_FOR
 import static seedu.expense.testutil.Assert.assertThrows;
 import static seedu.expense.testutil.TypicalExpenses.GRAB_HOME;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.expense.commons.exceptions.IllegalValueException;
@@ -26,9 +22,7 @@ public class JsonAdaptedExpenseTest {
     private static final String VALID_AMOUNT = GRAB_HOME.getAmount().toString();
     private static final String VALID_DATE = GRAB_HOME.getDate().toString();
     private static final String VALID_REMARK = GRAB_HOME.getRemark().toString();
-    private static final List<JsonAdaptedTag> VALID_TAGS = GRAB_HOME.getTags().stream()
-            .map(JsonAdaptedTag::new)
-            .collect(Collectors.toList());
+    private static final JsonAdaptedTag VALID_TAG = new JsonAdaptedTag(GRAB_HOME.getTag());
 
     @Test
     public void toModelType_validExpenseDetails_returnsExpense() throws Exception {
@@ -40,7 +34,7 @@ public class JsonAdaptedExpenseTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(INVALID_DESCRIPTION, VALID_AMOUNT, VALID_DATE, VALID_REMARK,
-                        VALID_TAGS);
+                        VALID_TAG);
         String expectedMessage = Description.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
@@ -49,7 +43,7 @@ public class JsonAdaptedExpenseTest {
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(null, VALID_AMOUNT, VALID_DATE,
-                        VALID_REMARK, VALID_TAGS);
+                        VALID_REMARK, VALID_TAG);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
@@ -58,7 +52,7 @@ public class JsonAdaptedExpenseTest {
     public void toModelType_invalidAmount_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(VALID_DESCRIPTION, INVALID_AMOUNT, VALID_DATE, VALID_REMARK,
-                        VALID_TAGS);
+                        VALID_TAG);
         String expectedMessage = Amount.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
@@ -67,7 +61,7 @@ public class JsonAdaptedExpenseTest {
     public void toModelType_nullAmount_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(VALID_DESCRIPTION, null, VALID_DATE,
-                        VALID_REMARK, VALID_TAGS);
+                        VALID_REMARK, VALID_TAG);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
@@ -76,7 +70,7 @@ public class JsonAdaptedExpenseTest {
     public void toModelType_invalidDate_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(VALID_DESCRIPTION, VALID_AMOUNT, INVALID_DATE, VALID_REMARK,
-                        VALID_TAGS);
+                        VALID_TAG);
         String expectedMessage = Date.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
@@ -85,18 +79,17 @@ public class JsonAdaptedExpenseTest {
     public void toModelType_nullDate_throwsIllegalValueException() {
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(VALID_DESCRIPTION, VALID_AMOUNT, null,
-                        VALID_REMARK, VALID_TAGS);
+                        VALID_REMARK, VALID_TAG);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
     }
 
     @Test
-    public void toModelType_invalidTags_throwsIllegalValueException() {
-        List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
-        invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
+    public void toModelType_invalidTag_throwsIllegalValueException() {
+        JsonAdaptedTag invalidTag = new JsonAdaptedTag(INVALID_TAG);
         JsonAdaptedExpense expense =
                 new JsonAdaptedExpense(VALID_DESCRIPTION, VALID_AMOUNT, VALID_DATE, VALID_REMARK,
-                        invalidTags);
+                        invalidTag);
         assertThrows(IllegalValueException.class, expense::toModelType);
     }
 

--- a/src/test/java/seedu/expense/testutil/EditExpenseDescriptorBuilder.java
+++ b/src/test/java/seedu/expense/testutil/EditExpenseDescriptorBuilder.java
@@ -1,9 +1,5 @@
 package seedu.expense.testutil;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import seedu.expense.logic.commands.EditCommand;
 import seedu.expense.logic.commands.EditCommand.EditExpenseDescriptor;
 import seedu.expense.model.expense.Amount;
@@ -35,7 +31,7 @@ public class EditExpenseDescriptorBuilder {
         descriptor.setDescription(expense.getDescription());
         descriptor.setAmount(expense.getAmount());
         descriptor.setDate(expense.getDate());
-        descriptor.setTags(expense.getTags());
+        descriptor.setTag(expense.getTag());
     }
 
     /**
@@ -66,9 +62,9 @@ public class EditExpenseDescriptorBuilder {
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditExpenseDescriptor}
      * that we are building.
      */
-    public EditExpenseDescriptorBuilder withTags(String... tags) {
-        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
-        descriptor.setTags(tagSet);
+    public EditExpenseDescriptorBuilder withTag(String tagString) {
+        Tag tag = new Tag(tagString);
+        descriptor.setTag(tag);
         return this;
     }
 

--- a/src/test/java/seedu/expense/testutil/ExpenseBuilder.java
+++ b/src/test/java/seedu/expense/testutil/ExpenseBuilder.java
@@ -1,7 +1,6 @@
 package seedu.expense.testutil;
 
-import java.util.HashSet;
-import java.util.Set;
+import static seedu.expense.model.ExpenseBook.DEFAULT_TAG;
 
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Date;
@@ -9,7 +8,6 @@ import seedu.expense.model.expense.Description;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.model.expense.Remark;
 import seedu.expense.model.tag.Tag;
-import seedu.expense.model.util.SampleDataUtil;
 
 /**
  * A utility class to help with building Expense objects.
@@ -25,7 +23,7 @@ public class ExpenseBuilder {
     private Amount amount;
     private Date date;
     private Remark remark;
-    private Set<Tag> tags;
+    private Tag tag;
 
     /**
      * Creates a {@code ExpenseBuilder} with the default details.
@@ -35,7 +33,7 @@ public class ExpenseBuilder {
         amount = new Amount(DEFAULT_AMOUNT);
         date = new Date(DEFAULT_DATE);
         remark = new Remark(DEFAULT_REMARK);
-        tags = new HashSet<>();
+        tag = DEFAULT_TAG;
     }
 
     /**
@@ -46,7 +44,7 @@ public class ExpenseBuilder {
         amount = expenseToCopy.getAmount();
         date = expenseToCopy.getDate();
         remark = expenseToCopy.getRemark();
-        tags = new HashSet<>(expenseToCopy.getTags());
+        tag = expenseToCopy.getTag();
     }
 
     /**
@@ -58,10 +56,10 @@ public class ExpenseBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Expense} that we are building.
+     * Parses the {@code tag} into a {@code Tag} and set it to the {@code Expense} that we are building.
      */
-    public ExpenseBuilder withTags(String ... tags) {
-        this.tags = SampleDataUtil.getTagSet(tags);
+    public ExpenseBuilder withTag(String tag) {
+        this.tag = new Tag(tag);
         return this;
     }
 
@@ -90,7 +88,7 @@ public class ExpenseBuilder {
     }
 
     public Expense build() {
-        return new Expense(description, amount, date, remark, tags);
+        return new Expense(description, amount, date, remark, tag);
     }
 
 }

--- a/src/test/java/seedu/expense/testutil/ExpenseUtil.java
+++ b/src/test/java/seedu/expense/testutil/ExpenseUtil.java
@@ -5,8 +5,6 @@ import static seedu.expense.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.expense.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.expense.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Set;
-
 import seedu.expense.logic.commands.AddCommand;
 import seedu.expense.logic.commands.EditCommand.EditExpenseDescriptor;
 import seedu.expense.model.expense.Expense;
@@ -32,9 +30,7 @@ public class ExpenseUtil {
         sb.append(PREFIX_DESCRIPTION + expense.getDescription().fullDescription + " ");
         sb.append(PREFIX_AMOUNT + expense.getAmount().toString() + " ");
         sb.append(PREFIX_DATE + expense.getDate().toString() + " ");
-        expense.getTags().stream().forEach(
-            s -> sb.append(PREFIX_TAG + s.tagName + " ")
-        );
+        sb.append(PREFIX_TAG + expense.getTag().tagName);
         return sb.toString();
     }
 
@@ -47,13 +43,9 @@ public class ExpenseUtil {
                 .append(description.fullDescription).append(" "));
         descriptor.getAmount().ifPresent(amount -> sb.append(PREFIX_AMOUNT).append(amount.toString()).append(" "));
         descriptor.getDate().ifPresent(date -> sb.append(PREFIX_DATE).append(date.toString()).append(" "));
-        if (descriptor.getTags().isPresent()) {
-            Set<Tag> tags = descriptor.getTags().get();
-            if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
-            } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
-            }
+        if (descriptor.getTag().isPresent()) {
+            Tag tag = descriptor.getTag().get();
+            sb.append(PREFIX_TAG).append(tag.tagName).append(" ");
         }
         return sb.toString();
     }

--- a/src/test/java/seedu/expense/testutil/TypicalExpenses.java
+++ b/src/test/java/seedu/expense/testutil/TypicalExpenses.java
@@ -2,10 +2,13 @@ package seedu.expense.testutil;
 
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_AMOUNT_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_AMOUNT_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_AMOUNT_MISC;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_DATE_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_DATE_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_DATE_MISC;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BUS;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_DESCRIPTION_FOOD;
+import static seedu.expense.logic.commands.CommandTestUtil.VALID_DESCRIPTION_MISC;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_TAG_FOOD;
 import static seedu.expense.logic.commands.CommandTestUtil.VALID_TAG_TRANSPORT;
 
@@ -16,6 +19,7 @@ import java.util.List;
 import seedu.expense.model.ExpenseBook;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
+import seedu.expense.model.tag.Tag;
 
 /**
  * A utility class containing a list of {@code Expense} objects to be used in tests.
@@ -26,17 +30,17 @@ public class TypicalExpenses {
             .withDate("02-07-2020")
             .withAmount("140.00")
             .withRemark("Birthday surprise with friends + birthday presents + birthday dinner")
-            .withTags("Girlfriend", "Shopping", "Food").build();
+            .withTag("Girlfriend").build();
     public static final Expense GRAB_HOME = new ExpenseBuilder().withDescription("Grab Home")
             .withRemark("Need to stop grabbing so much!")
             .withDate("01-07-2020").withAmount("15.00")
-            .withTags("Transport").build();
+            .withTag("Transport").build();
     public static final Expense ZARA = new ExpenseBuilder().withDescription("ZARA Jacket").withAmount("80.00")
             .withDate("30-06-2020")
-            .withTags("Shopping").build();
+            .withTag("Shopping").build();
     public static final Expense RAMEN = new ExpenseBuilder().withDescription("Ramen with Tyler").withAmount("18.50")
             .withDate("29-06-2020")
-            .withTags("Food").build();
+            .withTag("Food").build();
     public static final Expense PHONE_BILL = new ExpenseBuilder()
             .withDescription("Phone Bill Payment").withAmount("35.90")
             .withDate("29-06-2020").build();
@@ -58,11 +62,12 @@ public class TypicalExpenses {
     // Manually added - Expense's details found in {@code CommandTestUtil}
     public static final Expense FOOD = new ExpenseBuilder().withDescription(VALID_DESCRIPTION_FOOD)
             .withAmount(VALID_AMOUNT_FOOD).withDate(VALID_DATE_FOOD)
-            .withTags(VALID_TAG_FOOD).build();
+            .withTag(VALID_TAG_FOOD).build();
     public static final Expense BUS = new ExpenseBuilder().withDescription(VALID_DESCRIPTION_BUS)
             .withAmount(VALID_AMOUNT_BUS).withDate(VALID_DATE_BUS)
-            .withTags(VALID_TAG_TRANSPORT, VALID_TAG_FOOD)
-            .build();
+            .withTag(VALID_TAG_TRANSPORT).build();
+    public static final Expense MISC = new ExpenseBuilder().withDescription(VALID_DESCRIPTION_MISC)
+            .withAmount(VALID_AMOUNT_MISC).withDate(VALID_DATE_MISC).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
@@ -72,12 +77,13 @@ public class TypicalExpenses {
      * Returns an {@code ExpenseBook} with all the typical expenses.
      */
     public static ExpenseBook getTypicalExpenseBook() {
-        ExpenseBook ab = new ExpenseBook();
+        ExpenseBook eb = new ExpenseBook();
         for (Expense expense : getTypicalExpenses()) {
-            ab.addExpense(expense);
+            eb.addExpense(expense);
         }
-        ab.getBudgets().topupBudget(new Amount("10"));
-        return ab;
+        eb.getBudgets().topupBudget(new Amount("10"));
+        eb.addCategory(new Tag(VALID_TAG_TRANSPORT));
+        return eb;
     }
 
     public static List<Expense> getTypicalExpenses() {


### PR DESCRIPTION
* Change the multiplicity of Expenses->Tag to 1 instead of *
* If the user adds an expense without the tag field or leaves the tag description blank, the expense is tagged to the "Default" tag
* Update test cases and stock expenses used for testing that were previously associated with 0 or multiple tags to either 1 or the default tag
* Remove test cases that specifically test the behavior of Tags as a Set.
* Update JSON files