### PR TITLE
Fix error in message displayed when topping up a category-budget

### DIFF
--- a/src/main/java/seedu/expense/logic/commands/TopupCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/TopupCommand.java
@@ -56,7 +56,7 @@ public class TopupCommand extends Command {
 
         model.topupCategoryBudget(category, toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, category.tagName,
-                model.getTotalBudget().getAmount().asDouble()));
+                model.getCategoryBudget(category).getAmount().asDouble()));
     }
 
     @Override

--- a/src/main/java/seedu/expense/model/Model.java
+++ b/src/main/java/seedu/expense/model/Model.java
@@ -10,6 +10,7 @@ import seedu.expense.model.alias.AliasEntry;
 import seedu.expense.model.alias.AliasMap;
 import seedu.expense.model.budget.Budget;
 import seedu.expense.model.budget.CategoryBudget;
+import seedu.expense.model.budget.exceptions.CategoryBudgetNotFoundException;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.model.expense.exceptions.CategoryNotFoundException;
@@ -143,6 +144,11 @@ public interface Model {
      * Returns the budget.
      */
     Budget getTotalBudget();
+
+    /**
+     * Returns the category-budget.
+     */
+    CategoryBudget getCategoryBudget(Tag category) throws CategoryBudgetNotFoundException;
 
     /**
      * Adds the given amount to the budget.

--- a/src/main/java/seedu/expense/model/ModelManager.java
+++ b/src/main/java/seedu/expense/model/ModelManager.java
@@ -132,6 +132,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public CategoryBudget getCategoryBudget(Tag category) {
+        return expenseBook.getBudgets().getCategoryBudget(category);
+    }
+
+    @Override
     public void topupBudget(Amount amount) {
         expenseBook.topupBudget(amount);
     }

--- a/src/main/java/seedu/expense/model/budget/UniqueCategoryBudgetList.java
+++ b/src/main/java/seedu/expense/model/budget/UniqueCategoryBudgetList.java
@@ -7,6 +7,7 @@ import static seedu.expense.model.ExpenseBook.DEFAULT_TAG;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -131,6 +132,29 @@ public class UniqueCategoryBudgetList implements Budget, Iterable<CategoryBudget
 
     public CategoryBudget getDefaultCategory() {
         return defaultCategory;
+    }
+
+    /**
+     * Returns the {@code CategoryBudget} corresponding to the specified category.
+     *
+     * @throws CategoryBudgetNotFoundException if the supplied category does not exist in the list of category-budgets.
+     */
+    public CategoryBudget getCategoryBudget(Tag category) {
+        requireNonNull(category);
+
+        if (category.equals(DEFAULT_TAG)) {
+            return getDefaultCategory();
+        }
+
+        List<CategoryBudget> categoryBudgets = internalList.stream()
+                .filter(categoryBudget -> categoryBudget.getTag().equals(category))
+                .collect(Collectors.toList());
+
+        if (categoryBudgets.isEmpty()) {
+            throw new CategoryBudgetNotFoundException();
+        }
+
+        return categoryBudgets.get(0);
     }
 
     /**

--- a/src/test/java/seedu/expense/logic/commands/AddCategoryCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AddCategoryCommandTest.java
@@ -177,6 +177,11 @@ public class AddCategoryCommandTest {
         }
 
         @Override
+        public CategoryBudget getCategoryBudget(Tag category) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void topupBudget(Amount amount) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AddCommandTest.java
@@ -178,6 +178,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public CategoryBudget getCategoryBudget(Tag category) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void topupBudget(Amount amount) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/expense/logic/commands/DeleteCategoryCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/DeleteCategoryCommandTest.java
@@ -179,6 +179,11 @@ class DeleteCategoryCommandTest {
         }
 
         @Override
+        public CategoryBudget getCategoryBudget(Tag category) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void topupBudget(Amount amount) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/expense/logic/commands/SwitchCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/SwitchCommandTest.java
@@ -186,6 +186,11 @@ class SwitchCommandTest {
         }
 
         @Override
+        public CategoryBudget getCategoryBudget(Tag category) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void topupBudget(Amount amount) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
@@ -170,6 +170,11 @@ public class TopupCommandTest {
         }
 
         @Override
+        public CategoryBudget getCategoryBudget(Tag category) {
+            return budgets.getCategoryBudget(category);
+        }
+
+        @Override
         public void topupBudget(Amount amount) {
             budgets.topupBudget(amount);
         }


### PR DESCRIPTION
Fixes #142:

The message displayed when topping up a non-'Default' category-budget previously showed the total budget instead of the specific category-budget's new total, which is now fixed.