### PR TITLE
Change Amount datatype to BigDecimal, Fix DescriptionComparator

### DIFF
--- a/src/main/java/seedu/expense/logic/commands/TopupCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/TopupCommand.java
@@ -27,7 +27,7 @@ public class TopupCommand extends Command {
             + PREFIX_AMOUNT + "59.90 "
             + PREFIX_TAG + "Food";
 
-    public static final String MESSAGE_SUCCESS = "New budget amount for %s: $%.02f";
+    public static final String MESSAGE_SUCCESS = "New budget amount for %s: $%s";
     public static final String MESSAGE_CATEGORY_NOT_FOUND = "The expense book does not contain the category %s";
 
     private final Amount toAdd;
@@ -61,7 +61,7 @@ public class TopupCommand extends Command {
 
         model.topupCategoryBudget(category, toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, category.tagName,
-                model.getCategoryBudget(category).getAmount().asDouble()));
+                model.getCategoryBudget(category).getAmount()));
     }
 
     @Override

--- a/src/main/java/seedu/expense/model/ExpenseBook.java
+++ b/src/main/java/seedu/expense/model/ExpenseBook.java
@@ -215,7 +215,7 @@ public class ExpenseBook implements ReadOnlyExpenseBook, Statistics {
      * @see UniqueExpenseList#tallyExpenses()
      */
     @Override
-    public double tallyExpenses() {
+    public Amount tallyExpenses() {
         return expenses.tallyExpenses();
     }
 
@@ -233,7 +233,7 @@ public class ExpenseBook implements ReadOnlyExpenseBook, Statistics {
      * @see UniqueCategoryBudgetList#tallyAmounts()
      */
     @Override
-    public double tallyBudgets() {
+    public Amount tallyBudgets() {
         return budgets.tallyAmounts();
     }
 
@@ -243,8 +243,8 @@ public class ExpenseBook implements ReadOnlyExpenseBook, Statistics {
      * @return tallied balance of the expense book
      */
     @Override
-    public double tallyBalance() {
-        return tallyBudgets() - tallyExpenses();
+    public Amount tallyBalance() {
+        return tallyBudgets().subtract(tallyExpenses());
     }
 
     //// util methods

--- a/src/main/java/seedu/expense/model/Statistics.java
+++ b/src/main/java/seedu/expense/model/Statistics.java
@@ -1,5 +1,7 @@
 package seedu.expense.model;
 
+import seedu.expense.model.expense.Amount;
+
 /**
  * Statistical calculation of an expense book
  */
@@ -10,19 +12,19 @@ public interface Statistics {
      *
      * @return tallied amount
      */
-    double tallyExpenses();
+    Amount tallyExpenses();
 
     /**
      * Returns the tallied filtered budgets amount
      *
      * @return tallied amount
      */
-    double tallyBudgets();
+    Amount tallyBudgets();
 
     /**
      * Tallies the balance of filtered budgets and filtered expenses in the expense book.
      *
      * @return tallied balance of the expense book
      */
-    double tallyBalance();
+    Amount tallyBalance();
 }

--- a/src/main/java/seedu/expense/model/budget/CategoryBudget.java
+++ b/src/main/java/seedu/expense/model/budget/CategoryBudget.java
@@ -31,7 +31,7 @@ public class CategoryBudget implements Budget {
      * Tops up the budget by the specified {@code Amount}.
      */
     public void topupBudget(Amount toAdd) {
-        assert toAdd.value >= 0;
+        assert toAdd.greaterThanEquals(Amount.zeroAmount());
         amount = amount.add(toAdd);
     }
 

--- a/src/main/java/seedu/expense/model/budget/UniqueCategoryBudgetList.java
+++ b/src/main/java/seedu/expense/model/budget/UniqueCategoryBudgetList.java
@@ -76,15 +76,15 @@ public class UniqueCategoryBudgetList implements Budget, Iterable<CategoryBudget
      * Calculates the sum of the budgets in the category-budgets list.
      * @return sum of budgets.
      */
-    public double tallyAmounts() {
+    public Amount tallyAmounts() {
         int size = filteredList.size();
-        double sum = internalList.size() == size && size != 1 || isAllDefaultCategory()
-            ? defaultCategory.getAmount().asDouble()
-            : 0;
-        assert sum >= 0;
+        Amount sum = internalList.size() == size && size != 1 || isAllDefaultCategory()
+            ? defaultCategory.getAmount()
+            : Amount.zeroAmount();
+        assert sum.greaterThanEquals(Amount.zeroAmount());
         Iterator<CategoryBudget> i = iterator();
         while (i.hasNext()) {
-            sum += i.next().getAmount().asDouble();
+            sum = sum.add(i.next().getAmount());
         }
         return sum;
     }
@@ -174,7 +174,7 @@ public class UniqueCategoryBudgetList implements Budget, Iterable<CategoryBudget
 
     @Override
     public Amount getAmount() {
-        return new Amount(tallyAmounts());
+        return tallyAmounts();
     }
 
     @Override

--- a/src/main/java/seedu/expense/model/expense/Amount.java
+++ b/src/main/java/seedu/expense/model/expense/Amount.java
@@ -16,7 +16,7 @@ public class Amount implements Comparable<Amount> {
             "Expense Amount restrictions:\n"
             + "Amount Format: should only contain numbers and 1 '.', and should be in the <dollars>.<cents> format.\n"
             + "    \".<cents>\" input is optional but <dollars> should contain at least 1 digit.\n"
-            + "Value Restrictions: -10e9 to 10e9 inclusive";
+            + "Value Restrictions: 0 to 10e9 inclusive";
     public static final String VALIDATION_REGEX = "(?<dollars>\\d+)(.(?<cents>\\d{1,2}))?";
     private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_EVEN;
     private static final BigDecimal MAX_VALUE = new BigDecimal("10e9");

--- a/src/main/java/seedu/expense/model/expense/Amount.java
+++ b/src/main/java/seedu/expense/model/expense/Amount.java
@@ -20,7 +20,7 @@ public class Amount implements Comparable<Amount> {
     public static final String VALIDATION_REGEX = "(?<dollars>\\d+)(.(?<cents>\\d{1,2}))?";
     private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_EVEN;
     private static final BigDecimal MAX_VALUE = new BigDecimal("10e9");
-    private static final BigDecimal MIN_VALUE = new BigDecimal("-10e9");
+    private static final BigDecimal MIN_VALUE = new BigDecimal("0");
 
     // value in Amount stored as cents
     protected final BigDecimal value;

--- a/src/main/java/seedu/expense/model/expense/Amount.java
+++ b/src/main/java/seedu/expense/model/expense/Amount.java
@@ -3,30 +3,38 @@ package seedu.expense.model.expense;
 import static java.util.Objects.requireNonNull;
 import static seedu.expense.commons.util.AppUtil.checkArgument;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 /**
  * Represents an Expense's amount in the expense book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAmount(String)}
  */
-public class Amount {
-
+public class Amount implements Comparable<Amount> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Expense amount should only contain numbers and 1 '.', and should be in the {dollars}.{cents} format."
-                    + "{.cents} is optional but {dollars} should contain at least 1 digit.";
+            "Expense Amount restrictions:\n"
+            + "Amount Format: should only contain numbers and 1 '.', and should be in the <dollars>.<cents> format.\n"
+            + "    \".<cents>\" input is optional but <dollars> should contain at least 1 digit.\n"
+            + "Value Restrictions: -10e9 to 10e9 inclusive";
     public static final String VALIDATION_REGEX = "(?<dollars>\\d+)(.(?<cents>\\d{1,2}))?";
-    public final Integer value;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_EVEN;
+    private static final BigDecimal MAX_VALUE = new BigDecimal("10e9");
+    private static final BigDecimal MIN_VALUE = new BigDecimal("-10e9");
+
+    // value in Amount stored as cents
+    protected final BigDecimal value;
 
     /**
      * Constructs a {@code Amount}.
      *
      * @param amount A valid amount, as a {@code String}.
      */
-    public Amount(String amount) {
+    public Amount(String amount) throws IllegalArgumentException {
         requireNonNull(amount);
         checkArgument(isValidAmount(amount), MESSAGE_CONSTRAINTS);
 
-        double f = Double.parseDouble(amount);
-        value = toCents(f);
+        value = toCents(new BigDecimal(amount));
     }
 
     /**
@@ -35,58 +43,126 @@ public class Amount {
      * @param amount A valid amount, as a {@code double}.
      */
     public Amount(double amount) {
-        requireNonNull(amount);
+        this(String.valueOf(amount));
+    }
 
-        value = toCents(amount);
+    /**
+     * Constructor for Amount that already comes in cents.
+     * @param minTermAmount value already comes in cents.
+     */
+    public Amount(BigDecimal minTermAmount) {
+        requireNonNull(minTermAmount);
+        this.value = minTermAmount;
     }
 
     /**
      * Converts an amount (rounded to two decimal places) into cents.
      */
-    public static int toCents(double amount) {
-        return (int) Math.round(amount * 100);
+    private static BigDecimal toCents(BigDecimal amount) {
+        return amount.multiply(new BigDecimal("100"));
     }
 
     /**
      * Converts an amount (in cents) into the format [dollars].[cents]
      */
-    public static double toDollars(int cents) {
-        return cents / 100.0;
+    private static BigDecimal toDollars(BigDecimal amount) {
+        return amount.divide(new BigDecimal("100"), ROUNDING_MODE);
     }
 
     /**
      * Returns true if a given string is a valid amount.
      */
     public static boolean isValidAmount(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isWithinRange(new BigDecimal(test));
+    }
+
+    private static boolean isWithinRange(BigDecimal value) {
+        return value.compareTo(MAX_VALUE) <= 0 && value.compareTo(MIN_VALUE) >= 0;
     }
 
     /**
      * Returns a new {@code Amount} as the sum of the current {@code Amount} and the specified {@code Amount}.
+     * Uses the minTerm constructor so no need to divide the values by 100 beforehand.
      */
-    public Amount add(Amount amount) {
-        requireNonNull(amount);
-        Integer total = value + amount.value;
-        return new Amount(toDollars(total));
+    public Amount add(Amount other) {
+        requireNonNull(other);
+        return new Amount(this.value.add(other.value));
+    }
+
+    /**
+     * Returns a new {@code Amount} as the difference of the current {@code Amount} and the specified {@code Amount}.
+     * Uses the minTerm constructor so no need to divide the values by 100 beforehand.
+     */
+    public Amount subtract(Amount other) {
+        requireNonNull(other);
+        return new Amount(this.value.subtract(other.value));
+    }
+
+    /**
+     * Returns a new {@code Amount} as the result of the division of this {@code Amount}
+     * and the specified {@code Amount}.
+     * Uses the minTerm constructor so no need to divide the values by 100 beforehand.
+     */
+    public Amount divide(Amount other) {
+        requireNonNull(other);
+        assert !other.value.equals(BigDecimal.ZERO);
+
+        return new Amount(this.value.divide(other.value, ROUNDING_MODE));
+    }
+
+    /**
+     * Returns a new {@code Amount} as the result of the product of this {@code Amount}
+     * and the specified {@code Amount}.
+     * Uses the minTerm constructor so no need to divide the values by 100 beforehand.
+     */
+    public Amount multiply(Amount other) {
+        requireNonNull(other);
+        return new Amount(this.value.multiply(other.value));
     }
 
     /**
      * Returns the {@code Double} value of the amount.
+     * Warning: use only if absolutely required due to precision loss.
      */
-    public Double asDouble() {
-        return toDollars(value);
+    public Double getDoubleValue() {
+        return toDollars(value).doubleValue();
+    }
+
+    public static Amount zeroAmount() {
+        return new Amount("0");
+    }
+
+    public boolean greaterThan(Amount other) {
+        return this.value.compareTo(other.value) > 0;
+    }
+
+    public boolean smallerThan(Amount other) {
+        return this.value.compareTo(other.value) < 0;
+    }
+
+    public boolean greaterThanEquals(Amount other) {
+        return this.value.compareTo(other.value) >= 0;
+    }
+
+    public boolean smallerThanEquals(Amount other) {
+        return this.value.compareTo(other.value) <= 0;
     }
 
     @Override
     public String toString() {
-        return String.format("%.2f", asDouble());
+        BigDecimal output = toDollars(this.value);
+        return output.setScale(2, ROUNDING_MODE).toString();
     }
 
+    /**
+     * Equality for Amount.
+     * Note that BigDecimal equality should be calculated irrespective of scale.
+     */
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Amount // instanceof handles nulls
-                && value.equals(((Amount) other).value)); // state check
+                && value.compareTo(((Amount) other).value) == 0); // state check
     }
 
     @Override
@@ -94,4 +170,8 @@ public class Amount {
         return value.hashCode();
     }
 
+    @Override
+    public int compareTo(Amount o) {
+        return this.value.compareTo(o.value);
+    }
 }

--- a/src/main/java/seedu/expense/model/expense/AmountComparator.java
+++ b/src/main/java/seedu/expense/model/expense/AmountComparator.java
@@ -17,9 +17,7 @@ public class AmountComparator extends SortKeyComparator {
 
     @Override
     public int compare(Expense o1, Expense o2) {
-        int s1 = o1.getAmount().value;
-        int s2 = o2.getAmount().value;
-        return s1 - s2;
+        return o1.getAmount().compareTo(o2.getAmount());
     }
 
     @Override

--- a/src/main/java/seedu/expense/model/expense/DescriptionComparator.java
+++ b/src/main/java/seedu/expense/model/expense/DescriptionComparator.java
@@ -20,7 +20,7 @@ public class DescriptionComparator extends SortKeyComparator {
         String s1 = o1.getDescription().toString();
         String s2 = o2.getDescription().toString();
 
-        return s1.compareTo(s2);
+        return s1.compareToIgnoreCase(s2);
     }
 
     @Override

--- a/src/main/java/seedu/expense/model/expense/UniqueExpenseList.java
+++ b/src/main/java/seedu/expense/model/expense/UniqueExpenseList.java
@@ -146,11 +146,11 @@ public class UniqueExpenseList implements Iterable<Expense> {
      * Calculates the sum of the expenses in the expense list.
      * @return sum of expenses.
      */
-    public double tallyExpenses() {
-        double sum = 0;
+    public Amount tallyExpenses() {
+        Amount sum = new Amount("0");
         Iterator<Expense> i = iterator();
         while (i.hasNext()) {
-            sum += i.next().getAmount().asDouble();
+            sum = sum.add(i.next().getAmount());
         }
         return sum;
     }

--- a/src/main/java/seedu/expense/ui/BudgetDisplay.java
+++ b/src/main/java/seedu/expense/ui/BudgetDisplay.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import seedu.expense.commons.core.LogsCenter;
 import seedu.expense.model.Statistics;
+import seedu.expense.model.expense.Amount;
 
 /**
  * A ui for the budget balance to be displayed to the user.
@@ -19,7 +20,7 @@ import seedu.expense.model.Statistics;
 public class BudgetDisplay extends UiPart<Region> {
 
     private static final String FXML = "BudgetDisplay.fxml";
-    private static final String BUDGET_BALANCE = "$%.02f / $%.02f";
+    private static final String BUDGET_BALANCE = "$%s / $%s";
     private static final String HEADER_MESSAGE = "Budget balance:";
     private static final String GREEN_BAR_STYLE_CLASS = "green-bar";
     private static final String ORANGE_BAR_STYLE_CLASS = "orange-bar";
@@ -69,11 +70,15 @@ public class BudgetDisplay extends UiPart<Region> {
      * @return Progress as double.
      */
     private double getProgress() {
-        double budgetAmount = statistics.tallyBudgets();
-        assert budgetAmount >= 0;
-        double expensesSum = statistics.tallyExpenses();
-        assert expensesSum >= 0;
-        return 1 - expensesSum / budgetAmount;
+        Amount budgetAmount = statistics.tallyBudgets();
+        assert budgetAmount.greaterThanEquals(Amount.zeroAmount());
+        Amount expensesSum = statistics.tallyExpenses();
+        assert expensesSum.greaterThanEquals(Amount.zeroAmount());
+        if (budgetAmount.equals(new Amount(0))) {
+            return -1 / 0.0;
+        } else {
+            return 1 - expensesSum.divide(budgetAmount).getDoubleValue();
+        }
 
     }
 
@@ -83,8 +88,8 @@ public class BudgetDisplay extends UiPart<Region> {
      * @return Formatted budget balance as String.
      */
     private String budgetBalance() {
-        double budgetAmount = statistics.tallyBudgets();
-        double balance = statistics.tallyBalance();
+        Amount budgetAmount = statistics.tallyBudgets();
+        Amount balance = statistics.tallyBalance();
         return String.format(BUDGET_BALANCE, balance, budgetAmount);
     }
 

--- a/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/TopupCommandTest.java
@@ -40,7 +40,7 @@ public class TopupCommandTest {
         ModelStub modelStub = new ModelStub();
         Amount validAmount = new Amount("1");
         CommandResult commandResult = new TopupCommand(validAmount).execute(modelStub);
-        assertEquals(String.format(TopupCommand.MESSAGE_SUCCESS, DEFAULT_TAG.tagName, validAmount.asDouble()),
+        assertEquals(String.format(TopupCommand.MESSAGE_SUCCESS, DEFAULT_TAG.tagName, validAmount),
                 commandResult.getFeedbackToUser());
         assertEquals(validAmount, modelStub.budgets.getAmount());
     }

--- a/src/test/java/seedu/expense/model/ExpenseBookTest.java
+++ b/src/test/java/seedu/expense/model/ExpenseBookTest.java
@@ -19,6 +19,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.expense.model.budget.CategoryBudget;
 import seedu.expense.model.budget.UniqueCategoryBudgetList;
+import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.model.expense.exceptions.DuplicateExpenseException;
 import seedu.expense.model.tag.Tag;
@@ -124,18 +125,18 @@ public class ExpenseBookTest {
         }
 
         @Override
-        public double tallyExpenses() {
-            return -1; // should not be called
+        public Amount tallyExpenses() {
+            throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public double tallyBudgets() {
-            return -1; // should not be called
+        public Amount tallyBudgets() {
+            throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public double tallyBalance() {
-            return -1; // should not be called
+        public Amount tallyBalance() {
+            throw new AssertionError("This method should not be called.");
         }
     }
 

--- a/src/test/java/seedu/expense/model/expense/AmountTest.java
+++ b/src/test/java/seedu/expense/model/expense/AmountTest.java
@@ -9,11 +9,6 @@ import org.junit.jupiter.api.Test;
 public class AmountTest {
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Amount(null));
-    }
-
-    @Test
     public void constructor_invalidAmount_throwsIllegalArgumentException() {
         String invalidAmount = "";
         assertThrows(IllegalArgumentException.class, () -> new Amount(invalidAmount));


### PR DESCRIPTION
Let's change how we use Amount throughout our code, using Amount for representation of monetary value instead of Double.

Also change `DescriptionComparator` to use case-insensitive alphabetical sorting. Fixes #131

Change Amount datatype to BigDecimal
Add wrapper methods for arithmetic operations on Amount
Fixed Equality comparators of Amount
Change Statistics.java Interface and BudgetDisplay.java to use Amount

Fixes #133, fixes #124, fixes #117, 