### PR TITLE
Update CategoryNotFoundException and Expense Equality

### DIFF
--- a/src/main/java/seedu/expense/commons/core/Messages.java
+++ b/src/main/java/seedu/expense/commons/core/Messages.java
@@ -9,5 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX = "The expense index provided is invalid";
     public static final String MESSAGE_EXPENSES_LISTED_OVERVIEW = "%1$d expenses listed!";
+    public static final String MESSAGE_INVALID_CATEGORY = "The \"%s\" category does not exist in the expense book. "
+            + "If you need to, please add it using the \"AddCat\" command first.";
 
 }

--- a/src/main/java/seedu/expense/logic/commands/AddCategoryCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AddCategoryCommand.java
@@ -21,7 +21,7 @@ public class AddCategoryCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TAG + "Food";
 
-    public static final String MESSAGE_SUCCESS = "New category added: %s";
+    public static final String MESSAGE_SUCCESS = "New category added: %s ";
     public static final String MESSAGE_DUPLICATE_CATEGORY = "This category already exists in the expense book.";
 
     private final Tag toAdd;

--- a/src/main/java/seedu/expense/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AddCommand.java
@@ -29,11 +29,11 @@ public class AddCommand extends Command {
             + PREFIX_DATE + "04-10-2020 "
             + PREFIX_TAG + "friends ";
 
-    public static final String MESSAGE_SUCCESS = "New expense added: %1$s.";
-    public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book."
+    public static final String MESSAGE_SUCCESS = "New expense added: %1$s ";
+    public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book. "
             + "Expense should be updated ";
     public static final String MESSAGE_DEFAULT = "The category '%s' does not exist yet"
-            + " -- tagging as 'Default' instead.";
+            + " -- tagging as 'Default' instead. ";
 
     private final Expense toAdd;
 

--- a/src/main/java/seedu/expense/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AddCommand.java
@@ -29,10 +29,11 @@ public class AddCommand extends Command {
             + PREFIX_DATE + "04-10-2020 "
             + PREFIX_TAG + "friends ";
 
-    public static final String MESSAGE_SUCCESS = "New expense added: %1$s";
-    public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book";
+    public static final String MESSAGE_SUCCESS = "New expense added: %1$s.";
+    public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book."
+            + "Expense should be updated ";
     public static final String MESSAGE_DEFAULT = "The category '%s' does not exist yet"
-            + " -- tagging as 'Default' instead";
+            + " -- tagging as 'Default' instead.";
 
     private final Expense toAdd;
 

--- a/src/main/java/seedu/expense/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/AliasCommand.java
@@ -20,7 +20,7 @@ public class AliasCommand extends Command {
             + "[Command's current custom alias or if command has none, default command word]\n"
             + "Example: " + COMMAND_WORD + " find " + "get ";
 
-    public static final String MESSAGE_EDIT_ALIAS_SUCCESS = "Edited alias: [%s] becomes [%s]";
+    public static final String MESSAGE_EDIT_ALIAS_SUCCESS = "Edited alias: [%s] becomes [%s]. ";
 
     private final String previousAlias;
     private final String newAlias;

--- a/src/main/java/seedu/expense/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.expense.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Expense book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Expense book has been cleared! ";
 
 
     @Override

--- a/src/main/java/seedu/expense/logic/commands/DeleteCategoryCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/DeleteCategoryCommand.java
@@ -22,7 +22,7 @@ public class DeleteCategoryCommand extends Command {
         + PREFIX_TAG + "Food";
 
     public static final String MESSAGE_SUCCESS = "Existing category deleted: %s";
-    public static final String MESSAGE_INVALID_CATEGORY = "This category does not exist in the expense book.";
+    public static final String MESSAGE_INVALID_CATEGORY = "The \"%s\" category does not exist in the expense book. ";
 
     private final Tag toDelete;
 
@@ -39,7 +39,7 @@ public class DeleteCategoryCommand extends Command {
         requireNonNull(model);
 
         if (!model.hasCategory(toDelete)) {
-            throw new CommandException(MESSAGE_INVALID_CATEGORY);
+            throw new CommandException(String.format(MESSAGE_INVALID_CATEGORY, toDelete));
         }
 
         model.deleteCategory(toDelete);

--- a/src/main/java/seedu/expense/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/DeleteCommand.java
@@ -22,7 +22,7 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_EXPENSE_SUCCESS = "Deleted Expense: %1$s";
+    public static final String MESSAGE_DELETE_EXPENSE_SUCCESS = "Deleted Expense: %1$s ";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/expense/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/EditCommand.java
@@ -20,7 +20,6 @@ import seedu.expense.model.expense.Date;
 import seedu.expense.model.expense.Description;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.model.expense.Remark;
-import seedu.expense.model.expense.exceptions.CategoryNotFoundException;
 import seedu.expense.model.tag.Tag;
 
 /**
@@ -45,6 +44,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited expense: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book.";
+    public static final String MESSAGE_INVALID_CATEGORY = "The \"%s\" category does not exist in the expense book. "
+            + "Please add it using the \"AddCat\" command first.";
 
     private final Index index;
     private final EditExpenseDescriptor editExpenseDescriptor;
@@ -71,7 +72,7 @@ public class EditCommand extends Command {
         }
 
         if (editExpenseDescriptor.getTag().isPresent() && !model.hasCategory(editExpenseDescriptor.getTag().get())) {
-            throw new CategoryNotFoundException();
+            throw new CommandException(String.format(MESSAGE_INVALID_CATEGORY, editExpenseDescriptor.getTag().get()));
         }
 
         Expense expenseToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/expense/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/EditCommand.java
@@ -41,9 +41,9 @@ public class EditCommand extends Command {
             + PREFIX_AMOUNT + "10 "
             + PREFIX_DATE + "01-07-2020";
 
-    public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited expense: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book.";
+    public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited expense: %1$s ";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided. ";
+    public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book. ";
     public static final String MESSAGE_INVALID_CATEGORY = "The \"%s\" category does not exist in the expense book. "
             + "Please add it using the \"AddCat\" command first.";
 

--- a/src/main/java/seedu/expense/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Expense Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Expense Book as requested ... ";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/expense/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/HelpCommand.java
@@ -12,7 +12,7 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window. ";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/expense/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/ListCommand.java
@@ -13,7 +13,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all expenses";
+    public static final String MESSAGE_SUCCESS = "Listed all expenses. ";
 
 
     @Override

--- a/src/main/java/seedu/expense/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/RemarkCommand.java
@@ -28,8 +28,8 @@ public class RemarkCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_REMARK + "Likes to swim.";
 
-    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Expense: %1$s";
-    public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Expense: %1$s";
+    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Expense: %1$s ";
+    public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Expense: %1$s ";
 
     private final Index index;
     private final Remark remark;

--- a/src/main/java/seedu/expense/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/SortCommand.java
@@ -36,7 +36,7 @@ public class SortCommand extends Command {
             + PREFIX_SORT + "date "
             + PREFIX_SORT + "descriptionR ";
 
-    public static final String MESSAGE_SUCCESS = "Expenses sorted according to: %s";
+    public static final String MESSAGE_SUCCESS = "Expenses sorted according to: %s. ";
 
     private Comparator<Expense> expenseComparator;
     private List<String> sortOrder;

--- a/src/main/java/seedu/expense/logic/commands/SwitchCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/SwitchCommand.java
@@ -22,8 +22,8 @@ public class SwitchCommand extends Command {
         + "Example: " + COMMAND_WORD + " "
         + PREFIX_TAG + "Food ";
 
-    public static final String MESSAGE_INVALID_CATEGORY = "No such category account:  %1$s";
-    public static final String MESSAGE_SUCCESS = "Category expense switched:  %1$s";
+    public static final String MESSAGE_INVALID_CATEGORY = "No such category account:  %1$s. ";
+    public static final String MESSAGE_SUCCESS = "Category expense switched:  %1$s. ";
 
     private final Tag toMatch;
 

--- a/src/main/java/seedu/expense/logic/commands/TopupCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/TopupCommand.java
@@ -27,8 +27,9 @@ public class TopupCommand extends Command {
             + PREFIX_AMOUNT + "59.90 "
             + PREFIX_TAG + "Food";
 
-    public static final String MESSAGE_SUCCESS = "New budget amount for %s: $%.02f";
-    public static final String MESSAGE_CATEGORY_NOT_FOUND = "The expense book does not contain the category %s";
+    public static final String MESSAGE_SUCCESS = "New budget amount for %s: $%s";
+    public static final String MESSAGE_INVALID_CATEGORY = "The \"%s\" category does not exist in the expense book. "
+            + "If you need to, please add it using the \"AddCat\" command first.";
 
     private final Amount toAdd;
     private final Tag category;
@@ -55,8 +56,9 @@ public class TopupCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         if (!model.hasCategory(category)) {
-            throw new CommandException(String.format(MESSAGE_CATEGORY_NOT_FOUND, category.toString()));
+            throw new CommandException(String.format(MESSAGE_INVALID_CATEGORY, category));
         }
 
         model.topupCategoryBudget(category, toAdd);

--- a/src/main/java/seedu/expense/model/ExpenseBook.java
+++ b/src/main/java/seedu/expense/model/ExpenseBook.java
@@ -12,6 +12,7 @@ import seedu.expense.model.budget.UniqueCategoryBudgetList;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
 import seedu.expense.model.expense.UniqueExpenseList;
+import seedu.expense.model.expense.exceptions.CategoryNotFoundException;
 import seedu.expense.model.tag.Tag;
 import seedu.expense.model.tag.UniqueTagList;
 
@@ -111,7 +112,14 @@ public class ExpenseBook implements ReadOnlyExpenseBook, Statistics {
         budgets.topupBudget(amount);
     }
 
+    /**
+     * Tops up a category budget.
+     * @throws CategoryNotFoundException if requested category does not exist.
+     */
     public void topupCategoryBudget(Tag category, Amount amount) {
+        if (!tags.contains(category)) {
+            throw new CategoryNotFoundException(category);
+        }
         budgets.topupCategoryBudget(category, amount);
     }
 
@@ -135,6 +143,9 @@ public class ExpenseBook implements ReadOnlyExpenseBook, Statistics {
      */
     public void deleteCategory(Tag tag) {
         requireNonNull(tag);
+        if (!tags.contains(tag)) {
+            throw new CategoryNotFoundException(tag);
+        }
         tags.remove(tag);
         budgets.remove(new CategoryBudget(tag));
         expenses.resetExpenseCategory(expense -> expense.getTag().equals(tag));
@@ -166,6 +177,11 @@ public class ExpenseBook implements ReadOnlyExpenseBook, Statistics {
      */
     public void addExpense(Expense p) {
         requireNonNull(p);
+
+        if (!tags.contains(p.getTag())) {
+            throw new CategoryNotFoundException(p.getTag());
+        }
+
         expenses.add(p);
     }
 
@@ -177,6 +193,10 @@ public class ExpenseBook implements ReadOnlyExpenseBook, Statistics {
      */
     public void setExpense(Expense target, Expense editedExpense) {
         requireNonNull(editedExpense);
+
+        if (!tags.contains(editedExpense.getTag())) {
+            throw new CategoryNotFoundException(editedExpense.getTag());
+        }
 
         expenses.setExpense(target, editedExpense);
     }

--- a/src/main/java/seedu/expense/model/ModelManager.java
+++ b/src/main/java/seedu/expense/model/ModelManager.java
@@ -17,7 +17,6 @@ import seedu.expense.model.budget.Budget;
 import seedu.expense.model.budget.CategoryBudget;
 import seedu.expense.model.expense.Amount;
 import seedu.expense.model.expense.Expense;
-import seedu.expense.model.expense.exceptions.CategoryNotFoundException;
 import seedu.expense.model.tag.Tag;
 
 /**
@@ -142,10 +141,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void topupCategoryBudget(Tag category, Amount amount) throws CategoryNotFoundException {
-        if (!expenseBook.containsCategory(category)) {
-            throw new CategoryNotFoundException();
-        }
+    public void topupCategoryBudget(Tag category, Amount amount) {
 
         expenseBook.topupCategoryBudget(category, amount);
     }

--- a/src/main/java/seedu/expense/model/expense/Expense.java
+++ b/src/main/java/seedu/expense/model/expense/Expense.java
@@ -59,8 +59,8 @@ public class Expense {
     }
 
     /**
-     * Returns true if both expenses of the same description have at least one other identity field that is the same.
-     * This defines a weaker notion of equality between two expenses.
+     * Returns true if both expenses have the same description, amount and date.
+     * The same level of equality is defined as the this#equals method.
      */
     public boolean isSameExpense(Expense otherExpense) {
         if (otherExpense == this) {
@@ -69,12 +69,13 @@ public class Expense {
 
         return otherExpense != null
                 && otherExpense.getDescription().equals(getDescription())
-                && (otherExpense.getAmount().equals(getAmount()) || otherExpense.getDate().equals(getDate()));
+                && (otherExpense.getAmount().equals(getAmount())
+                && otherExpense.getDate().equals(getDate()));
     }
 
     /**
-     * Returns true if both expenses have the same identity and data fields.
-     * This defines a stronger notion of equality between two expenses.
+     * Returns true if both expenses have the same description, amount and date.
+     * This defines a strong notion of equality between two expenses.
      */
     @Override
     public boolean equals(Object other) {
@@ -102,7 +103,7 @@ public class Expense {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getDescription())
-                .append(" Amount: ")
+                .append(" Amount: $")
                 .append(getAmount())
                 .append(" Date: ")
                 .append(getDate())

--- a/src/main/java/seedu/expense/model/expense/exceptions/CategoryNotFoundException.java
+++ b/src/main/java/seedu/expense/model/expense/exceptions/CategoryNotFoundException.java
@@ -1,7 +1,18 @@
 package seedu.expense.model.expense.exceptions;
 
+import static seedu.expense.commons.core.Messages.MESSAGE_INVALID_CATEGORY;
+
+import seedu.expense.model.tag.Tag;
+
 /**
- * Signals that the operation is unable to find the specified category.
+ * Signals that the operation is unable to find the specified category (internal non-user-visible exception)
  */
 public class CategoryNotFoundException extends RuntimeException {
+    public CategoryNotFoundException(Tag category) {
+        super(String.format(MESSAGE_INVALID_CATEGORY, category));
+    }
+
+    public CategoryNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/seedu/expense/storage/JsonSerializableExpenseBook.java
+++ b/src/main/java/seedu/expense/storage/JsonSerializableExpenseBook.java
@@ -22,6 +22,8 @@ class JsonSerializableExpenseBook {
 
     public static final String MESSAGE_DUPLICATE_CATEGORY = "Tags list contains duplicate tags.";
     public static final String MESSAGE_DUPLICATE_EXPENSE = "Expenses list contains duplicate expense(s).";
+    public static final String MESSAGE_INVALID_CATEGORY = "Trying to add an expense to the \"%s\" category which does"
+            + " not exist in the expense book.";
 
     private final List<JsonAdaptedExpense> expenses = new ArrayList<>();
     private final JsonAdaptedBudgetList budgets;
@@ -69,6 +71,9 @@ class JsonSerializableExpenseBook {
             Expense expense = jsonAdaptedExpense.toModelType();
             if (expenseBook.hasExpense(expense)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_EXPENSE);
+            }
+            if (!expenseBook.containsCategory(expense.getTag())) {
+                throw new IllegalValueException(String.format(MESSAGE_INVALID_CATEGORY, expense.getTag()));
             }
             expenseBook.addExpense(expense);
         }

--- a/src/test/data/JsonSerializableExpenseBookTest/duplicateExpenseLedger.json
+++ b/src/test/data/JsonSerializableExpenseBookTest/duplicateExpenseLedger.json
@@ -8,7 +8,7 @@
   }, {
     "description": "Lunch Bak Chor Mee",
     "amount": "3.00",
-    "date": "05-10-2020",
+    "date": "04-10-2020",
     "remark" : "",
     "tagged": "Default"
   } ],

--- a/src/test/java/seedu/expense/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/expense/logic/LogicManagerTest.java
@@ -88,6 +88,7 @@ public class LogicManagerTest {
                 + DATE_DESC_FOOD + TAG_DESC_FOOD;
         Expense expectedExpense = new ExpenseBuilder(FOOD).build();
         ModelManager expectedModel = new ModelManager();
+        expectedModel.addCategory(expectedExpense.getTag());
         expectedModel.addExpense(expectedExpense);
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);

--- a/src/test/java/seedu/expense/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/AliasCommandTest.java
@@ -70,7 +70,7 @@ public class AliasCommandTest {
     public void execute_removeSingleAlias_revertBack() throws CommandException {
         ModelStubWithAliasMap modelStub = new ModelStubWithAliasMap();
         assertEquals(
-                new CommandResult("Removed alias. [get] is no longer alias for [find]."),
+                new CommandResult("Removed alias. [get] is no longer alias for [find]. "),
                 new AliasCommand("get", "find").execute(modelStub)
         );
     }

--- a/src/test/java/seedu/expense/logic/commands/DeleteCategoryCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/DeleteCategoryCommandTest.java
@@ -56,9 +56,8 @@ class DeleteCategoryCommandTest {
         DeleteCategoryCommand deleteCategoryCommand = new DeleteCategoryCommand(invalidTag);
         DeleteCategoryCommandTest.ModelStub modelStub = new DeleteCategoryCommandTest.ModelStubWithTag(validTag);
 
-        assertThrows(CommandException.class,
-            String.format(DeleteCategoryCommand.MESSAGE_INVALID_CATEGORY, invalidTag),
-                () -> deleteCategoryCommand.execute(modelStub));
+        assertThrows(CommandException.class, String.format(DeleteCategoryCommand.MESSAGE_INVALID_CATEGORY,
+                invalidTag), () -> deleteCategoryCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/expense/logic/commands/DeleteCategoryCommandTest.java
+++ b/src/test/java/seedu/expense/logic/commands/DeleteCategoryCommandTest.java
@@ -57,7 +57,8 @@ class DeleteCategoryCommandTest {
         DeleteCategoryCommandTest.ModelStub modelStub = new DeleteCategoryCommandTest.ModelStubWithTag(validTag);
 
         assertThrows(CommandException.class,
-            DeleteCategoryCommand.MESSAGE_INVALID_CATEGORY, () -> deleteCategoryCommand.execute(modelStub));
+            String.format(DeleteCategoryCommand.MESSAGE_INVALID_CATEGORY, invalidTag),
+                () -> deleteCategoryCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/expense/model/ExpenseBookTest.java
+++ b/src/test/java/seedu/expense/model/ExpenseBookTest.java
@@ -68,13 +68,16 @@ public class ExpenseBookTest {
 
     @Test
     public void hasExpense_expenseInExpenseBook_returnsTrue() {
+        expenseBook.addCategory(FEL_BDAY.getTag());
         expenseBook.addExpense(FEL_BDAY);
         assertTrue(expenseBook.hasExpense(FEL_BDAY));
     }
 
     @Test
     public void hasExpense_expenseWithSameIdentityFieldsInExpenseBook_returnsTrue() {
+        expenseBook.addCategory(FEL_BDAY.getTag());
         expenseBook.addExpense(FEL_BDAY);
+        expenseBook.addCategory(new Tag(VALID_TAG_TRANSPORT));
         Expense editedAlice = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT)
                 .build();
         assertTrue(expenseBook.hasExpense(editedAlice));

--- a/src/test/java/seedu/expense/model/ModelManagerTest.java
+++ b/src/test/java/seedu/expense/model/ModelManagerTest.java
@@ -83,6 +83,7 @@ public class ModelManagerTest {
 
     @Test
     public void hasExpense_expenseInExpenseBook_returnsTrue() {
+        modelManager.addCategory(FEL_BDAY.getTag());
         modelManager.addExpense(FEL_BDAY);
         assertTrue(modelManager.hasExpense(FEL_BDAY));
     }

--- a/src/test/java/seedu/expense/model/expense/ExpenseTest.java
+++ b/src/test/java/seedu/expense/model/expense/ExpenseTest.java
@@ -33,15 +33,15 @@ public class ExpenseTest {
         editedFelBD = new ExpenseBuilder(FEL_BDAY).withDescription(VALID_DESCRIPTION_BUS).build();
         assertFalse(FEL_BDAY.isSameExpense(editedFelBD));
 
-        // same description, same amount, different attributes -> returns true
+        // same description, same amount, different attributes -> returns false
         editedFelBD = new ExpenseBuilder(FEL_BDAY).withDate(VALID_DATE_BUS)
                 .withTag(VALID_TAG_TRANSPORT).build();
-        assertTrue(FEL_BDAY.isSameExpense(editedFelBD));
+        assertFalse(FEL_BDAY.isSameExpense(editedFelBD));
 
-        // same description, same date, different attributes -> returns true
+        // same description, same date, different attributes -> returns false
         editedFelBD = new ExpenseBuilder(FEL_BDAY).withAmount(VALID_AMOUNT_BUS)
                 .withTag(VALID_TAG_TRANSPORT).build();
-        assertTrue(FEL_BDAY.isSameExpense(editedFelBD));
+        assertFalse(FEL_BDAY.isSameExpense(editedFelBD));
 
         // same description, same amount, same date, different attributes -> returns true
         editedFelBD = new ExpenseBuilder(FEL_BDAY).withTag(VALID_TAG_TRANSPORT).build();

--- a/src/test/java/seedu/expense/testutil/ExpenseBookBuilder.java
+++ b/src/test/java/seedu/expense/testutil/ExpenseBookBuilder.java
@@ -24,6 +24,9 @@ public class ExpenseBookBuilder {
      * Adds a new {@code Expense} to the {@code ExpenseBook} that we are building.
      */
     public ExpenseBookBuilder withExpense(Expense expense) {
+        if (!expenseBook.containsCategory(expense.getTag())) {
+            expenseBook.addCategory(expense.getTag());
+        }
         expenseBook.addExpense(expense);
         return this;
     }


### PR DESCRIPTION
Update codebase to use CategoryNotFoundException as a runtime exception.
Handle category not found exceptions separately at a command level by throwing CommandException.
Add checks for CategoryNotFoundException in ExpenseBook and JsonSerializableExpenseBook.


Tighten notion of Expense equality to include BOTH date and amount. 

Update test and data files to accommodate stricter checks of having to add a category before being able to add an expense to that category.

Fixes #141, fixes #121, fixes #101 