### PR TITLE
Fix rounding error in Amount causing problems in BudgetDisplay 

### DIFF
--- a/src/main/java/seedu/expense/model/expense/Amount.java
+++ b/src/main/java/seedu/expense/model/expense/Amount.java
@@ -99,32 +99,10 @@ public class Amount implements Comparable<Amount> {
     }
 
     /**
-     * Returns a new {@code Amount} as the result of the division of this {@code Amount}
-     * and the specified {@code Amount}.
-     * Uses the minTerm constructor so no need to divide the values by 100 beforehand.
-     */
-    public Amount divide(Amount other) {
-        requireNonNull(other);
-        assert !other.value.equals(BigDecimal.ZERO);
-
-        return new Amount(this.value.divide(other.value, ROUNDING_MODE));
-    }
-
-    /**
-     * Returns a new {@code Amount} as the result of the product of this {@code Amount}
-     * and the specified {@code Amount}.
-     * Uses the minTerm constructor so no need to divide the values by 100 beforehand.
-     */
-    public Amount multiply(Amount other) {
-        requireNonNull(other);
-        return new Amount(this.value.multiply(other.value));
-    }
-
-    /**
-     * Returns the {@code Double} value of the amount.
+     * Returns the {@code Double} dollar value of the amount.
      * Warning: use only if absolutely required due to precision loss.
      */
-    public Double getDoubleValue() {
+    public Double getDoubleDollarValue() {
         return toDollars(value).doubleValue();
     }
 

--- a/src/main/java/seedu/expense/model/expense/Amount.java
+++ b/src/main/java/seedu/expense/model/expense/Amount.java
@@ -102,7 +102,7 @@ public class Amount implements Comparable<Amount> {
      * Returns the {@code Double} dollar value of the amount.
      * Warning: use only if absolutely required due to precision loss.
      */
-    public Double getDoubleDollarValue() {
+    public Double getDollarAsDoubleValue() {
         return toDollars(value).doubleValue();
     }
 

--- a/src/main/java/seedu/expense/ui/BudgetDisplay.java
+++ b/src/main/java/seedu/expense/ui/BudgetDisplay.java
@@ -74,10 +74,11 @@ public class BudgetDisplay extends UiPart<Region> {
         assert budgetAmount.greaterThanEquals(Amount.zeroAmount());
         Amount expensesSum = statistics.tallyExpenses();
         assert expensesSum.greaterThanEquals(Amount.zeroAmount());
+
         if (budgetAmount.equals(new Amount(0))) {
             return -1 / 0.0;
         } else {
-            return 1 - expensesSum.divide(budgetAmount).getDoubleValue();
+            return 1 - (expensesSum.getDoubleDollarValue() / budgetAmount.getDoubleDollarValue());
         }
 
     }

--- a/src/main/java/seedu/expense/ui/BudgetDisplay.java
+++ b/src/main/java/seedu/expense/ui/BudgetDisplay.java
@@ -78,7 +78,7 @@ public class BudgetDisplay extends UiPart<Region> {
         if (budgetAmount.equals(new Amount(0))) {
             return -1 / 0.0;
         } else {
-            return 1 - (expensesSum.getDoubleDollarValue() / budgetAmount.getDoubleDollarValue());
+            return 1 - (expensesSum.getDollarAsDoubleValue() / budgetAmount.getDollarAsDoubleValue());
         }
 
     }


### PR DESCRIPTION
Removed division and multiplication from Amount because that would result in inconsistent cent and dollar representation.

Fix bug that caused progress bar to present no progress.