### PR TITLE
Exception messages updated to display aliases if any

### DIFF
--- a/src/main/java/seedu/expense/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/EditCommand.java
@@ -42,7 +42,7 @@ public class EditCommand extends Command {
             + PREFIX_DATE + "01-07-2020";
 
     public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited expense: %1$s ";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided. ";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to ed\u200eit must be provided. ";
     public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the expense book. ";
     public static final String MESSAGE_INVALID_CATEGORY = "The \"%s\" category does not exist in the expense book. "
             + "Please add it using the \"AddCat\" command first.";

--- a/src/main/java/seedu/expense/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/expense/logic/commands/RemarkCommand.java
@@ -20,9 +20,9 @@ public class RemarkCommand extends Command {
 
     public static final String COMMAND_WORD = "remark";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the remark of the expense identified "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the rem\u200eark of the expense identified "
             + "by the index number used in the last expense listing. "
-            + "Existing remark will be overwritten by the input.\n"
+            + "Existing rem\u200eark will be overwritten by the input.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_REMARK + "[REMARK]\n"
             + "Example: " + COMMAND_WORD + " 1 "

--- a/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
+++ b/src/main/java/seedu/expense/logic/parser/ExpenseBookParser.java
@@ -65,64 +65,70 @@ public class ExpenseBookParser {
         }
 
         String commandWord = matcher.group("commandWord");
+        String maybeAlias = commandWord;
         if (aliasMap != null && aliasMap.hasAlias(commandWord)) {
             commandWord = aliasMap.getValue(commandWord);
         }
         final String arguments = matcher.group("arguments");
         LogsCenter.getLogger(LogicManager.class).info(
                 "----------------[USER COMMAND][" + commandWord + " " + arguments + "]");
-        switch (commandWord) {
+        try {
+            switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            case AddCommand.COMMAND_WORD:
+                return new AddCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+            case EditCommand.COMMAND_WORD:
+                return new EditCommandParser().parse(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+            case DeleteCommand.COMMAND_WORD:
+                return new DeleteCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            case ClearCommand.COMMAND_WORD:
+                return new ClearCommand();
 
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
+            case FindCommand.COMMAND_WORD:
+                return new FindCommandParser().parse(arguments);
 
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            case ListCommand.COMMAND_WORD:
+                return new ListCommand();
 
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+            case ExitCommand.COMMAND_WORD:
+                return new ExitCommand();
 
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            case HelpCommand.COMMAND_WORD:
+                return new HelpCommand();
 
-        case RemarkCommand.COMMAND_WORD:
-            return new RemarkCommandParser().parse(arguments);
+            case RemarkCommand.COMMAND_WORD:
+                return new RemarkCommandParser().parse(arguments);
 
-        case TopupCommand.COMMAND_WORD:
-            return new TopupCommandParser().parse(arguments);
+            case TopupCommand.COMMAND_WORD:
+                return new TopupCommandParser().parse(arguments);
 
-        case AddCategoryCommand.COMMAND_WORD:
-            return new AddCategoryCommandParser().parse(arguments);
+            case AddCategoryCommand.COMMAND_WORD:
+                return new AddCategoryCommandParser().parse(arguments);
 
-        case DeleteCategoryCommand.COMMAND_WORD:
-            return new DeleteCategoryCommandParser().parse(arguments);
+            case DeleteCategoryCommand.COMMAND_WORD:
+                return new DeleteCategoryCommandParser().parse(arguments);
 
-        case SwitchCommand.COMMAND_WORD:
-            return new SwitchCommandParser().parse(arguments);
+            case SwitchCommand.COMMAND_WORD:
+                return new SwitchCommandParser().parse(arguments);
 
-        case AliasCommand.COMMAND_WORD:
-            return new AliasCommandParser().parse(arguments);
+            case AliasCommand.COMMAND_WORD:
+                return new AliasCommandParser().parse(arguments);
 
-        case SortCommand.COMMAND_WORD:
-            return new SortCommandParser().parse(arguments);
+            case SortCommand.COMMAND_WORD:
+                return new SortCommandParser().parse(arguments);
 
-        case ResetAliasCommand.COMMAND_WORD:
-            return new ResetAliasCommandParser().parse(arguments);
+            case ResetAliasCommand.COMMAND_WORD:
+                return new ResetAliasCommandParser().parse(arguments);
 
-        default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            default:
+                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            }
+        } catch (ParseException e) {
+            String updatedMessage = e.getMessage().replace(commandWord, maybeAlias);
+            throw new ParseException(updatedMessage);
         }
     }
 }

--- a/src/main/java/seedu/expense/logic/parser/Parser.java
+++ b/src/main/java/seedu/expense/logic/parser/Parser.java
@@ -7,7 +7,6 @@ import seedu.expense.logic.parser.exceptions.ParseException;
  * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.
  */
 public interface Parser<T extends Command> {
-
     /**
      * Parses {@code userInput} into a command and returns it.
      *

--- a/src/main/java/seedu/expense/model/alias/AliasMap.java
+++ b/src/main/java/seedu/expense/model/alias/AliasMap.java
@@ -21,6 +21,7 @@ import seedu.expense.logic.commands.FindCommand;
 import seedu.expense.logic.commands.HelpCommand;
 import seedu.expense.logic.commands.ListCommand;
 import seedu.expense.logic.commands.RemarkCommand;
+import seedu.expense.logic.commands.ResetAliasCommand;
 import seedu.expense.logic.commands.SortCommand;
 import seedu.expense.logic.commands.SwitchCommand;
 import seedu.expense.logic.commands.TopupCommand;
@@ -36,7 +37,7 @@ public class AliasMap {
     public static final String UNCHANGED_ALIAS = "Previous and updated alias must not be the same.";
     public static final String ALIAS_NOT_FOUND = "The [%s] alias cannot be found.";
     public static final String ALIAS_ALPHABETS_ONLY = "Only case-sensitive alphabets can be used as aliases.";
-    public static final String ALIAS_COMMAND_UNALIASABLE = "`alias` and `reset alias` commands cannot have aliases.";
+    public static final String ALIAS_COMMAND_UNALIASABLE = "`alias` and `resetAlias` commands cannot have aliases.";
     public static final String MESSAGE_OVERRIDE_ALIAS = "Override existing alias instead: %s";
     public static final IntPredicate IS_ALPHABET_ASCII = x -> (x > 96 && x < 123 || x > 64 && x < 91);
     public static final Set<String> RESERVED_KEYWORDS = Set.of(
@@ -44,7 +45,8 @@ public class AliasMap {
             EditCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
             HelpCommand.COMMAND_WORD, ListCommand.COMMAND_WORD, RemarkCommand.COMMAND_WORD,
             TopupCommand.COMMAND_WORD, AliasCommand.COMMAND_WORD, AddCategoryCommand.COMMAND_WORD,
-            DeleteCategoryCommand.COMMAND_WORD, SwitchCommand.COMMAND_WORD, SortCommand.COMMAND_WORD
+            DeleteCategoryCommand.COMMAND_WORD, SwitchCommand.COMMAND_WORD, SortCommand.COMMAND_WORD,
+            ResetAliasCommand.COMMAND_WORD
     );
 
     // Maps String alias to String default_command
@@ -134,7 +136,8 @@ public class AliasMap {
         requireNonNull(prev);
         requireNonNull(update);
         assert (prev.getValue().equals(update.getValue())) : "Must replace the same value (command) alias";
-        if (prev.getKey().equals(AliasCommand.COMMAND_WORD)) {
+        if (prev.getKey().equals(AliasCommand.COMMAND_WORD)
+                || prev.getKey().equals(ResetAliasCommand.COMMAND_WORD)) {
             throw new IllegalArgumentException(ALIAS_COMMAND_UNALIASABLE);
         }
         if (!update.getKey().chars().allMatch(IS_ALPHABET_ASCII)) {


### PR DESCRIPTION
Fixes #99 

Fixed by catching and updating the exception message in the ExpenseBookParser before throwing out the same type of error with a new message. However, command string pattern used within the error messages themselves will also get replaced with this fix. Thus, invisible (non-printable) escape character ('\u200e') was injected for RemarkCommand.MESSAGE_USAGE and EditCommand.MESSAGE_NOT_EDITED to prevent replacement of the words `"edit"` and `"remark"` into their aliases within the error messages.

Illustration on escape character used:
- `"ran\u200edom"` will display as `"random"` in the app
- `"ran\u200edom".equals("random")` will evaluate to false